### PR TITLE
Chat API 테스트 성공, 일반 이메일 로그인도 카카오 로그인와 응답 통일 구현, 로그아웃 API JSESSIONI 까지 삭제 되도록 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,13 +51,17 @@ jobs:
           scp "$JAR_NAME" ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/ubuntu/app.jar
 
           echo "🔁 EC2 애플리케이션 재시작 중..."
-          ssh ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << EOF
+          ssh ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << 'EOF'
+          # 기존 프로세스 종료
           pkill -f 'java -jar' || true
-        
+
           echo "🔐 환경변수 설정 및 앱 실행..."
           nohup env \
           JWT_SECRET="${{ secrets.JWT_SECRET }}" \
           KAKAO_SECRET_KEY="${{ secrets.KAKAO_SECRET_KEY }}" \
+          KAKAO_CLIENT_ID="${{ secrets.KAKAO_CLIENT_ID }}" \
+          KAKAO_CLIENT_SECRET="${{ secrets.KAKAO_CLIENT_SECRET }}" \
+          KAKAO_REDIRECT_URI="${{ secrets.KAKAO_REDIRECT_URI }}" \
           DATABASE_USERNAME="${{ secrets.DATABASE_USERNAME }}" \
           DATABASE_PASSWORD="${{ secrets.DATABASE_PASSWORD }}" \
           DRIVER_CLASS_NAME="${{ secrets.DRIVER_CLASS_NAME }}" \
@@ -67,19 +71,20 @@ jobs:
           AWS_SECRET_KEY="${{ secrets.AWS_SECRET_KEY }}" \
           BUCKET_NAME="${{ secrets.BUCKET_NAME }}" \
           java -jar /home/ubuntu/app.jar \
-          --server.port=8080 --server.address=0.0.0.0 > log.txt 2>&1 &
-        
-          echo "⏳ 서버 시작 대기 중..."
-          sleep 10
-        
-          echo "📄 로그 확인 시도..."
-          if [ -f log.txt ]; then
-          tail -n 20 log.txt || echo "❌ 로그 파일 tail 실패"
-          else
-          echo "❌ log.txt 파일 없음 (앱 실행 실패 가능성)"
-          fi
-          EOF
+          --server.port=8081 --server.address=0.0.0.0 > /home/ubuntu/ei-backend.log 2>&1 &
 
+          echo "⏳ 서버 시작 대기 중..."
+          sleep 8
+
+          echo "🩺 헬스체크"
+          curl -s -I https://api.dongcheolcoding.life/actuator/health | sed -n '1p'
+
+          echo "🔍 카카오 redirect_uri 확인(https 고정 확인)"
+          curl -s -I "https://api.dongcheolcoding.life/oauth2/authorization/kakao" | sed -n 's/^location:/Location:/Ip'
+
+          echo "📄 최근 로그 50줄"
+          tail -n 50 /home/ubuntu/ei-backend.log || true
+          EOF
 
         env:
           JWT_SECRET: ${{ secrets.JWT_SECRET }}

--- a/src/main/java/com/example/ei_backend/config/WebSocketConfig.java
+++ b/src/main/java/com/example/ei_backend/config/WebSocketConfig.java
@@ -22,11 +22,18 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
+        // 1) 네이티브 WS (Postman 테스트용)
         registry.addEndpoint("/ws-chat")
-                .addInterceptors(jwtHandshakeInterceptor)          // (현재 방식 유지 시) ?token= 검증
-                .setHandshakeHandler(userPrincipalHandshakeHandler) // Principal 주입
+                .addInterceptors(jwtHandshakeInterceptor)
+                .setHandshakeHandler(userPrincipalHandshakeHandler)
+                .setAllowedOriginPatterns("*"); // withSockJS() 없음!
+
+        // 2) 기존 SockJS 엔드포인트 (프론트에서 SockJS 클라이언트 쓸 때)
+        registry.addEndpoint("/ws-chat-sockjs")
+                .addInterceptors(jwtHandshakeInterceptor)
+                .setHandshakeHandler(userPrincipalHandshakeHandler)
                 .setAllowedOriginPatterns("*")
-                .withSockJS(); // SockJS 쓰면 실제로는 /ws-chat/** 로 내부 경로가 생깁니다.
+                .withSockJS();
     }
 
     @Override

--- a/src/main/java/com/example/ei_backend/controller/ChatRestController.java
+++ b/src/main/java/com/example/ei_backend/controller/ChatRestController.java
@@ -18,11 +18,9 @@ public class ChatRestController {
 
     private final ChatService chatService;
 
-    // 멤버가 상담자 이메일로 방 열기(기존 있으면 그 방 id 반황)
     @PostMapping("/open")
     public ResponseEntity<Long> openRoom(@RequestParam String supportEmail,
-                                         @AuthenticationPrincipal UserPrincipal  principal) {
-        String memberEmail = principal.getUsername();
+                                         @AuthenticationPrincipal(expression = "username") String memberEmail) {
         Long roomId = chatService.openRoom(memberEmail, supportEmail);
         return ResponseEntity.ok(roomId);
     }

--- a/src/main/java/com/example/ei_backend/exception/NotFoundException.java
+++ b/src/main/java/com/example/ei_backend/exception/NotFoundException.java
@@ -1,0 +1,11 @@
+package com.example.ei_backend.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String target) {
+        super("존재하지 않는 " + target);
+    }
+}

--- a/src/main/java/com/example/ei_backend/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/ei_backend/security/JwtAuthenticationFilter.java
@@ -36,7 +36,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         log.info("[JwtFilter] 요청 경로: {}", path);
 
         // ✅ SockJS/WS 경로는 핸드셰이크 인터셉터에서 검증하므로 필터 우회
-        if (path.startsWith("/ws-chat")) return true;
+        if (path.startsWith("/ws-chat") || path.startsWith("/ws-chat-sockjs")) return true;
 
         return path.startsWith("/swagger-ui")
                 || path.equals("/swagger-ui.html")

--- a/src/main/java/com/example/ei_backend/security/SecurityConfig.java
+++ b/src/main/java/com/example/ei_backend/security/SecurityConfig.java
@@ -68,6 +68,7 @@ public class SecurityConfig {
                 )
                 //Saved request 캐시 끄기 (불필요한 세션 저장/리다이렉트 방지)
                 .requestCache(c -> c.disable())
+                .logout(l -> l.disable())
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
@@ -92,9 +93,9 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
 
-                // ✅ 401/403을 ApiResponse JSON으로 통일
+                //  401/403을 ApiResponse JSON으로 통일
                 .exceptionHandling(ex -> ex
-                        // ✅ /api/**는 반드시 JSON 401 (리다이렉트 금지)
+                        //  /api/**는 반드시 JSON 401 (리다이렉트 금지)
                         .defaultAuthenticationEntryPointFor(
                                 jsonAuthenticationEntryPoint,
                                 new AntPathRequestMatcher("/api/**")
@@ -117,7 +118,7 @@ public class SecurityConfig {
     }
 
     /**
-     * ✅ Spring Security 6.5+ 대응용 Kakao Token Client 설정
+     *  Spring Security 6.5+ 대응용 Kakao Token Client 설정
      */
     @Bean
     public OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> accessTokenResponseClient() {

--- a/src/main/java/com/example/ei_backend/security/SecurityConfig.java
+++ b/src/main/java/com/example/ei_backend/security/SecurityConfig.java
@@ -81,7 +81,9 @@ public class SecurityConfig {
                                 "/api/auth/verify/**",
                                 "/oauth2/**", "/login/oauth2/**",
                                 "/actuator/health",
-                                "/.well-known/**"
+                                "/.well-known/**",
+                                "/ws-chat", "/ws-chat/**", "/ws-chat-sockjs", "/ws-chat-sockjs/**"
+
                         ).permitAll()
                         // 프로필 이미지는 인증 필수
                         .requestMatchers(HttpMethod.PATCH,  "/api/auth/profile/image").authenticated()

--- a/src/main/java/com/example/ei_backend/websocket/JwtHandshakeInterceptor.java
+++ b/src/main/java/com/example/ei_backend/websocket/JwtHandshakeInterceptor.java
@@ -9,18 +9,15 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.stereotype.Component;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.HandshakeInterceptor;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import java.net.URI;
 import java.util.Map;
-import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
-public class JwtHandshakeInterceptor  implements HandshakeInterceptor {
+public class JwtHandshakeInterceptor implements HandshakeInterceptor {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
@@ -30,33 +27,38 @@ public class JwtHandshakeInterceptor  implements HandshakeInterceptor {
                                    ServerHttpResponse response,
                                    WebSocketHandler wsHandler,
                                    Map<String, Object> attributes) {
-        // 1) 쿼리 파라미터네서 token 추출
-        URI uri = request.getURI();
-        MultiValueMap<String, String> params = UriComponentsBuilder.fromUri(uri).build().getQueryParams();
-        String token = Optional.ofNullable(params.getFirst("token"))
-                // 2) 없으면 Authorization 헤더 시도
-                .orElseGet(() -> {
-                    String h = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
-                    if (h != null && h.startsWith("Bearer ")) return h.substring(7);
-                    return null;
-                });
-        if (token == null || !jwtTokenProvider.validateToken(token)) {
-            return false; //핸드세이크 거부
+
+        // 1) ?token= 우선
+        String token = null;
+        var params = UriComponentsBuilder.fromUri(request.getURI()).build().getQueryParams();
+        token = params.getFirst("token");
+
+        // 2) 없으면 Authorization 헤더
+        if (token == null) {
+            String h = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+            if (h != null && h.startsWith("Bearer ")) token = h.substring(7);
         }
 
-        String email = jwtTokenProvider.getUsername(token);
-        User user = userRepository.findByEmail(email).orElse(null);
-        if (user == null) return false;
+        if (token == null || !jwtTokenProvider.validateToken(token)) {
+            response.setStatusCode(org.springframework.http.HttpStatus.UNAUTHORIZED);
+            return false;
+        }
 
-        // 컨트롤러/핸들러에서 꺼내 쓸 수 있게 저장
+        // ⚠️ jwtTokenProvider의 메서드 이름을 필터와 통일하세요 (getEmail 사용 권장)
+        String email = jwtTokenProvider.getEmail(token); // getUsername 대신 getEmail 사용(토큰 sub가 이메일이면 동일)
+        User user = userRepository.findByEmail(email).orElse(null);
+        if (user == null) {
+            response.setStatusCode(org.springframework.http.HttpStatus.UNAUTHORIZED);
+            return false;
+        }
+
+        // 컨트롤러/핸들러에서 꺼내 쓰도록 'email'과 'userDetails' 둘 다 저장
+        attributes.put("email", email);
         attributes.put("userDetails", new UserDetailsImpl(user));
         return true;
-
     }
 
     @Override
-    public void afterHandshake(ServerHttpRequest request,
-                               ServerHttpResponse response,
-                               WebSocketHandler wsHandler,
-                               Exception exception) {}
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                               WebSocketHandler wsHandler, Exception exception) {}
 }

--- a/src/main/java/com/example/ei_backend/websocket/StompPrincipal.java
+++ b/src/main/java/com/example/ei_backend/websocket/StompPrincipal.java
@@ -2,11 +2,8 @@ package com.example.ei_backend.websocket;
 
 import java.security.Principal;
 
-public class StompPrincipal implements Principal {
-    private final String name; // 보통 이메일
-
+public final class StompPrincipal implements Principal {
+    private final String name;
     public StompPrincipal(String name) { this.name = name; }
-
-    @Override
-    public String getName() { return name; }
+    @Override public String getName() { return name; }
 }


### PR DESCRIPTION
Chat API 테스트 성공, 일반 이메일 로그인도 카카오 로그인와 응답 통일 구현, 로그아웃 API JSESSIONI 까지 삭제 되도록 구현