### PR TITLE
메일 속 링크 클릭 → 브라우저가 /api/auth/verify?email=...&code=... GET 요청 → 컨트롤러에…

### DIFF
--- a/src/main/java/com/example/ei_backend/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/ei_backend/repository/RefreshTokenRepository.java
@@ -3,10 +3,19 @@ package com.example.ei_backend.repository;
 import com.example.ei_backend.domain.entity.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
     Optional<RefreshToken> findByEmail(String email);
+
+    @Transactional
+    default void saveOrUpdate(String email, String token) {
+        save(RefreshToken.builder()
+                .email(email)
+                .token(token)
+                .build());
+    }
 }


### PR DESCRIPTION
…서 authService.verifyAndSignup(...) 호출 → 회원가입 완료 + 토큰 발급/쿠키 저장 → 프론트 성공 페이지로 리다이렉트