### PR TITLE
feat(payment): 카카오페이 승인/저장 플로우를 DB 기반으로 전환하고 멱등성 보장

### DIFF
--- a/src/main/java/com/example/ei_backend/controller/PaymentController.java
+++ b/src/main/java/com/example/ei_backend/controller/PaymentController.java
@@ -100,12 +100,19 @@ public class PaymentController {
     })
 
     @PostMapping("/approve")
+// @GetMapping("/approve")  // 프론트가 GET으로 호출한다면 이걸로 교체
     public ResponseEntity<ApiResponse<String>> approvePayment(
+            @RequestParam("orderId") String orderId,
             @RequestParam("pg_token") String pgToken,
             @AuthenticationPrincipal UserPrincipal me
     ) {
-        String result = kakaoPayService.approve(pgToken, me.getUsername());
-        return ResponseEntity.ok(ApiResponse.ok("결제가 완료되었습니다."));
+        String result = kakaoPayService.approve(
+                orderId,
+                pgToken,
+                me.getUsername(),   // = 이메일(네 UserPrincipal이 이메일을 username으로 쓰는 구조면)
+                me.getUserId()      // Long userId
+        );
+        return ResponseEntity.ok(ApiResponse.ok(result));
     }
 
 

--- a/src/main/java/com/example/ei_backend/domain/dto/KakaoPayApproveRequestDto.java
+++ b/src/main/java/com/example/ei_backend/domain/dto/KakaoPayApproveRequestDto.java
@@ -1,5 +1,6 @@
 package com.example.ei_backend.domain.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.NotBlank;
@@ -17,5 +18,6 @@ public class KakaoPayApproveRequestDto {
     private String partnerUserId;    // 가맹점 회원 ID
 
     @NotBlank
+    @JsonAlias({"pg_token", "pgToken"})
     private String pgToken;          // 카카오페이에서 전달받은 pg_token
 }

--- a/src/main/java/com/example/ei_backend/domain/dto/KakaoPayApproveResponseDto.java
+++ b/src/main/java/com/example/ei_backend/domain/dto/KakaoPayApproveResponseDto.java
@@ -1,0 +1,36 @@
+package com.example.ei_backend.domain.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter @Setter
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoPayApproveResponseDto {
+    private String aid;
+    private String tid;
+    private String cid;
+
+    private String partnerOrderId;
+    private String partnerUserId;
+
+    private String itemName;
+    private String paymentMethodType;
+
+    private Amount amount;
+    private String approvedAt; // 예: 2025-08-21T05:05:20Z
+
+    @Getter @Setter
+    @NoArgsConstructor
+    public static class Amount {
+        private int total;
+        private int taxFree;
+        private int vat;
+        private int point;
+        private int discount;
+        private int greenDeposit;
+    }
+}

--- a/src/main/java/com/example/ei_backend/domain/entity/Payment.java
+++ b/src/main/java/com/example/ei_backend/domain/entity/Payment.java
@@ -10,20 +10,29 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class Payment {
-    @Id
-    @GeneratedValue
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "user_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "course_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "course_id")
     private Course course;
 
+    @Column(nullable = false, unique = true)
+    private String orderId;
+
+    @Column(nullable = false, unique = true)
+    private String tid;
+
+    @Column(nullable = false)
     private int amount;
 
     @Enumerated(EnumType.STRING)
@@ -32,7 +41,12 @@ public class Payment {
     @Enumerated(EnumType.STRING)
     private PaymentStatus status;
 
-    private String pgTid;                 // 카카오 TID
+    @Column(nullable = false)
+    private LocalDateTime paymentDate;
+
+    // 둘 중 하나만 쓰세요. tid와 의미가 겹치면 혼란을 줄 수 있어요.
+    private String pgTid;
     private LocalDateTime requestedAt;
     private LocalDateTime approvedAt;
 }
+

--- a/src/main/java/com/example/ei_backend/domain/entity/PendingPayment.java
+++ b/src/main/java/com/example/ei_backend/domain/entity/PendingPayment.java
@@ -1,0 +1,40 @@
+package com.example.ei_backend.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PendingPayment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // AUTO_INCREMENT (MySQL/MariaDB)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String orderId;
+
+    @Column(nullable = false)
+    private String tid;
+
+    @Column(nullable = false)
+    private String userEmail;
+
+    @Column(nullable = false)
+    private Long courseId;
+
+    @Column(nullable = false)
+    private Integer amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PaymentStatus status;
+
+    public void markApproved()   { this.status = PaymentStatus.APPROVED; }
+    public void markCancelled()  { this.status = PaymentStatus.CANCELLED; }
+    public void markFailed()     { this.status = PaymentStatus.FAILED; }
+}

--- a/src/main/java/com/example/ei_backend/repository/PaymentRepository.java
+++ b/src/main/java/com/example/ei_backend/repository/PaymentRepository.java
@@ -11,4 +11,6 @@ import java.util.List;
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
     boolean existsByUserIdAndCourseIdAndStatus(Long userId, Long courseId, PaymentStatus status);
     List<Payment> findByUserIdOrderByIdDesc(Long userId);
+
+    boolean existsByTid(String tid);
 }

--- a/src/main/java/com/example/ei_backend/repository/PendingPaymentRepository.java
+++ b/src/main/java/com/example/ei_backend/repository/PendingPaymentRepository.java
@@ -1,0 +1,12 @@
+package com.example.ei_backend.repository;
+
+import com.example.ei_backend.domain.entity.PendingPayment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PendingPaymentRepository extends JpaRepository<PendingPayment, Long> {
+    Optional<PendingPayment> findByOrderId(String orderId);
+}

--- a/src/main/java/com/example/ei_backend/service/KakaoPayService.java
+++ b/src/main/java/com/example/ei_backend/service/KakaoPayService.java
@@ -1,13 +1,11 @@
 package com.example.ei_backend.service;
 
 import com.example.ei_backend.domain.dto.KakaoPayApproveRequestDto;
+import com.example.ei_backend.domain.dto.KakaoPayApproveResponseDto;
 import com.example.ei_backend.domain.dto.KakaoPayReadyRequestDto;
 import com.example.ei_backend.domain.dto.KakaoPayReadyResponseDto;
-import com.example.ei_backend.domain.entity.Course;
-import com.example.ei_backend.domain.entity.UserCourse;
-import com.example.ei_backend.repository.CourseRepository;
-import com.example.ei_backend.repository.UserCourseRepository;
-import com.example.ei_backend.repository.UserRepository;
+import com.example.ei_backend.domain.entity.*;
+import com.example.ei_backend.repository.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,8 +19,12 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -34,6 +36,8 @@ public class KakaoPayService {
     private final UserRepository userRepository;
     private final CourseRepository courseRepository;
     private final UserCourseRepository userCourseRepository;
+    private final PendingPaymentRepository pendingPaymentRepository;
+    private final PaymentRepository paymentRepository;
 
     @Value("${kakaopay.api.secret.key}")
     private String kakaoPaySecretKey;
@@ -50,17 +54,10 @@ public class KakaoPayService {
     @Value("${app.client.host}") // 예: https://api.dongcheolcoding.life
     private String apiBaseUrl;
 
-    private final Map<String, String> orderIdByUser = new ConcurrentHashMap<>(); // userEmail -> orderId
-    private final Map<String, String> tidByOrderId = new ConcurrentHashMap<>();  // orderId -> tid
-    private final Map<String, Long> courseIdByOrderId = new ConcurrentHashMap<>(); // orderId -> courseId
-
 
     @Transactional
     public KakaoPayReadyResponseDto ready(Course course, String userEmail) {
         try {
-   //         log.info(" [KakaoPay] Admin Key: {}", kakaoPaySecretKey);
-   //         log.info(" [KakaoPay] CID: {}", cid);
-
             log.info(" course title = {}", course.getTitle());
             log.info(" course price = {}", course.getPrice());
             log.info(" userEmail = {}", userEmail);
@@ -68,9 +65,14 @@ public class KakaoPayService {
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_JSON);
             headers.set("Authorization", "SECRET_KEY " + kakaoPaySecretKey);
-            log.info(" Authorization 헤더: {}", headers.getFirst("Authorization"));
 
             String orderId = UUID.randomUUID().toString();
+
+            String approvalUrlWithOrderId = UriComponentsBuilder
+                    .fromHttpUrl(frontSuccessUrl)
+                    .queryParam("orderId", orderId)
+                    .build(true)
+                    .toUriString();
 
             KakaoPayReadyRequestDto request = KakaoPayReadyRequestDto.builder()
                     .cid(cid)
@@ -81,15 +83,13 @@ public class KakaoPayService {
                     .totalAmount(course.getPrice())
                     .taxFreeAmount(0)
                     .vatAmount(course.getPrice() / 10)
-                    //  카카오 → 프론트 라우트로 보냄
-                    .approvalUrl(frontSuccessUrl)                               // 프론트 콜백
-                    .cancelUrl(apiBaseUrl + "/api/payment/cancel")              // 백엔드 취소
-                    .failUrl(apiBaseUrl + "/api/payment/fail")                  // 백엔드 실패
+                    .approvalUrl(approvalUrlWithOrderId)
+                    .cancelUrl(apiBaseUrl + "/api/payment/cancel")
+                    .failUrl(apiBaseUrl + "/api/payment/fail")
                     .build();
 
             HttpEntity<KakaoPayReadyRequestDto> entity = new HttpEntity<>(request, headers);
 
-            //  우선 String으로 응답 받아서 로그 확인
             ResponseEntity<String> rawResponse = new RestTemplate().postForEntity(
                     "https://open-api.kakaopay.com/online/v1/payment/ready",
                     entity,
@@ -98,17 +98,21 @@ public class KakaoPayService {
 
             log.info(" [카카오 응답 원문] {}", rawResponse.getBody());
 
-            // ✅ 응답을 DTO로 변환
             ObjectMapper objectMapper = new ObjectMapper();
-            KakaoPayReadyResponseDto res = objectMapper.readValue(rawResponse.getBody(),
-                    KakaoPayReadyResponseDto.class);
+            KakaoPayReadyResponseDto res = objectMapper.readValue(
+                    rawResponse.getBody(), KakaoPayReadyResponseDto.class);
 
-            orderIdByUser.put(userEmail, orderId);
-            tidByOrderId.put(orderId, res.getTid());
-            courseIdByOrderId.put(orderId, course.getId());
-
-//            userTidMap.put(userEmail, responseDto.getTid());
-//            userOrderIdMap.put(userEmail, orderId);
+            // ✅ Map에 넣던 부분 삭제하고, DB에 보관
+            pendingPaymentRepository.save(
+                    PendingPayment.builder()
+                            .orderId(orderId)
+                            .tid(res.getTid())
+                            .userEmail(userEmail)
+                            .courseId(course.getId())
+                            .amount(course.getPrice())
+                            .status(PaymentStatus.READY)
+                            .build()
+            );
 
             return res;
 
@@ -122,53 +126,92 @@ public class KakaoPayService {
         }
     }
 
+
     @Transactional
-    public String approve(String pgToken, String userEmail) {
-        String orderId = orderIdByUser.get(userEmail);
-        if (orderId == null) throw new IllegalStateException("주문정보가 없습니다. 다시 시도해 주세요.");
+    public String approve(String orderId, String pgToken, String userEmail, Long userId) {
+        // 1) 보류 결제 조회
+        PendingPayment pending = pendingPaymentRepository.findByOrderId(orderId)
+                .orElseThrow(() -> new IllegalStateException("주문정보가 없습니다. 다시 시도해 주세요."));
+        if (!pending.getUserEmail().equals(userEmail)) {
+            throw new IllegalStateException("주문 소유자가 아닙니다.");
+        }
+        if (pending.getStatus() == PaymentStatus.APPROVED) {
+            return "{\"message\":\"already approved\"}";
+        }
 
-        String tid = tidByOrderId.get(orderId);
-        if (tid == null) throw new IllegalStateException("TID가 없습니다. 다시 시도해 주세요.");
-
-        Long courseId = courseIdByOrderId.get(orderId);
-        if (courseId == null) throw new IllegalStateException("코스 정보가 없습니다. 다시 시도해 주세요.");
-
-        // 카카오 승인
+        // 2) 카카오 승인 호출 (DTO로 수신)
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.set("Authorization", "SECRET_KEY " + kakaoPaySecretKey);
 
-        var req = KakaoPayApproveRequestDto.builder()
-                .cid(cid).tid(tid).partnerOrderId(orderId)
-                .partnerUserId(userEmail).pgToken(pgToken).build();
+        KakaoPayApproveRequestDto req = KakaoPayApproveRequestDto.builder()
+                .cid(cid)
+                .tid(pending.getTid())
+                .partnerOrderId(orderId)
+                .partnerUserId(userEmail)
+                .pgToken(pgToken)
+                .build();
 
-        var entity = new HttpEntity<>(req, headers);
-        var response = new RestTemplate().postForEntity(
-                "https://open-api.kakaopay.com/online/v1/payment/approve", entity, String.class);
+        ResponseEntity<KakaoPayApproveResponseDto> resp = new RestTemplate().postForEntity(
+                "https://open-api.kakaopay.com/online/v1/payment/approve",
+                new HttpEntity<>(req, headers),
+                KakaoPayApproveResponseDto.class
+        );
 
-        // 수강 등록 멱등
-        var user = userRepository.findByEmail(userEmail)
-                .orElseThrow(() -> new IllegalStateException("사용자 없음"));
-        var course = courseRepository.findById(courseId)
-                .orElseThrow(() -> new IllegalStateException("코스 없음"));
-
-        boolean enrolled = userCourseRepository.existsByUserIdAndCourseId(user.getId(), course.getId());
-        if (!enrolled) {
-            userCourseRepository.save(
-                    UserCourse.builder()
-                            .user(user)
-                            .course(course)
-                            .registeredAt(java.time.LocalDateTime.now())
-                            .build()
-            );
+        KakaoPayApproveResponseDto body = Optional.ofNullable(resp.getBody())
+                .orElseThrow(() -> new IllegalStateException("카카오 승인 응답이 비어있습니다."));
+        if (!resp.getStatusCode().is2xxSuccessful()) {
+            throw new IllegalStateException("카카오 승인 실패: " + resp.getStatusCode());
         }
 
-        // 임시 맵 정리
-        tidByOrderId.remove(orderId);
-        courseIdByOrderId.remove(orderId);
-        orderIdByUser.remove(userEmail);
+        // 3) 금액/시간 검증
+        int approvedAmount = body.getAmount().getTotal();
+        if (approvedAmount != pending.getAmount()) {
+            throw new IllegalStateException("금액 불일치");
+        }
+        LocalDateTime approvedAt = (body.getApprovedAt() != null)
+                ? OffsetDateTime.parse(body.getApprovedAt()).toLocalDateTime()
+                : LocalDateTime.now();
 
-        return response.getBody();
+        // 4) 수강 등록 멱등
+        var user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new IllegalStateException("사용자 없음"));
+        var course = courseRepository.findById(pending.getCourseId())
+                .orElseThrow(() -> new IllegalStateException("코스 없음"));
+
+        if (!userCourseRepository.existsByUserIdAndCourseId(user.getId(), course.getId())) {
+            userCourseRepository.save(UserCourse.builder()
+                    .user(user)
+                    .course(course)
+                    .registeredAt(LocalDateTime.now())
+                    .build());
+        }
+
+        // 5) Payment 저장
+        if (!paymentRepository.existsByTid(pending.getTid())) {
+            Payment payment = Payment.builder()
+                    .orderId(orderId)
+                    .tid(pending.getTid())
+                    .user(user)
+                    .course(course)
+                    .amount(approvedAmount)
+                    .status(PaymentStatus.APPROVED)
+                    .paymentDate(approvedAt)
+                    .build();
+            paymentRepository.save(payment);
+        }
+
+        // 6) 상태 변경
+        pending.setStatus(PaymentStatus.APPROVED);
+
+        // 7) 필요하면 프론트에 넘길 DTO를 만들어 반환해도 됨.
+        return "{\"message\":\"approved\",\"tid\":\"" + body.getTid() + "\"}";
+    }
+
+    private java.time.LocalDateTime parseKakaoTime(String s) {
+        if (s == null || s.isBlank()) return java.time.LocalDateTime.now();
+        return java.time.OffsetDateTime.parse(s).toLocalDateTime();
+
     }
 
 


### PR DESCRIPTION
READY → APPROVE 전 과정을 DB 기반으로 변경
리다이렉트 성공 시 프론트 → 백엔드 /approve 호출 구조 확립
결제정보 저장을 ConcurrentHashMap → JPA 엔티티로 교체
Payment 매핑 충돌 해결(중복 컬럼 매핑 제거)