### PR TITLE
feat(course): 내 코스 목록 및 결제 프리뷰 조회 기능 개선

### DIFF
--- a/src/main/java/com/example/ei_backend/repository/LectureRepository.java
+++ b/src/main/java/com/example/ei_backend/repository/LectureRepository.java
@@ -13,7 +13,7 @@ public interface LectureRepository extends JpaRepository<Lecture, Long> {
 
     List<Lecture> findByCourseIdOrderByOrderIndexAsc(Long courseId);
 
-    int countByCourseId(Long courseId);
+    long countByCourseId(Long courseId);
 
     @Query("select coalesce(sum(l.durationSec), 0) from Lecture l where l.course.id = :courseId")
     int sumDurationByCourseId(@Param("courseId") Long courseId);

--- a/src/main/java/com/example/ei_backend/repository/UserCourseRepository.java
+++ b/src/main/java/com/example/ei_backend/repository/UserCourseRepository.java
@@ -1,11 +1,17 @@
 package com.example.ei_backend.repository;
 
 import com.example.ei_backend.domain.entity.UserCourse;
+import jakarta.persistence.Entity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface UserCourseRepository extends JpaRepository<UserCourse, Long> {
     boolean existsByUserIdAndCourseId(Long userId, Long courseId);
-    Page<UserCourse> findByUserId(Long userId, Pageable pageable);
+
+    @EntityGraph(attributePaths = "course")
+    Page<UserCourse> findByUser_Id(Long userId, Pageable pageable);
 }


### PR DESCRIPTION
- UserCourseRepository에 @EntityGraph(course) 추가하여 N+1 문제 방지
- CourseService.findMyCourses:
  - progress를 0~1.0 비율로 변환
  - imageUrl, completedCount, totalCount 포함하도록 응답 개선
- CourseRepository:
  - findByIdAndPublishedTrueAndDeletedFalse 메서드 추가
  - 공개 코스 조회/검증 시 활용
- LectureRepository:
  - sumDurationByCourseId 쿼리 추가 (총 강의 길이 계산)
  - countByCourseId 반환타입 long으로 변경
- CourseService.getPurchasePreview 구현
  - 코스 단건 조회 시 강의 개수와 전체 길이 합산 제공
- NotFoundException을 활용해 일관된 예외 처리 적용