### PR TITLE
fix: Lecture 영상 등록 시 durationSec 동기화 로직 추가

### DIFF
--- a/src/main/java/com/example/ei_backend/domain/entity/Lecture.java
+++ b/src/main/java/com/example/ei_backend/domain/entity/Lecture.java
@@ -74,4 +74,7 @@ public class Lecture extends BaseTimeEntity {
     }
 
 
+    public void updateDurationFromVideo(int sec) {
+        this.durationSec = Math.max(0, sec);
+    }
 }


### PR DESCRIPTION
- LectureCommandService.confirm() 내부에서 VideoAsset.markReady() 호출 후 Lecture.durationSec 값을 VideoAsset.durationSec 으로 갱신하도록 수정
- Lecture 엔티티에 updateDurationFromVideo(int sec) 메서드 추가 → 영상 길이 정보가 항상 Lecture 테이블에 반영되도록 보장
- 기존에 durationSec=0으로 저장되던 문제 해결