### PR TITLE
feat(mypage): 사용자의 결제내역을 마이페이지에 노출

### DIFF
--- a/src/main/java/com/example/ei_backend/repository/PaymentRepository.java
+++ b/src/main/java/com/example/ei_backend/repository/PaymentRepository.java
@@ -3,6 +3,8 @@ package com.example.ei_backend.repository;
 import com.example.ei_backend.domain.entity.Payment;
 import com.example.ei_backend.domain.entity.PaymentStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,4 +15,15 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     List<Payment> findByUserIdOrderByIdDesc(Long userId);
 
     boolean existsByTid(String tid);
+
+    // 결제 + 코스 한 번에 가져오기 (N+1 방지)
+    @Query("""
+           select p
+           from Payment p
+           join fetch p.course c
+           where p.user.id = :userId
+             and p.status = com.example.ei_backend.domain.entity.PaymentStatus.APPROVED
+           order by p.paymentDate desc
+           """)
+    List<Payment> findApprovedByUserIdWithCourse(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/ei_backend/service/KakaoPayService.java
+++ b/src/main/java/com/example/ei_backend/service/KakaoPayService.java
@@ -197,11 +197,14 @@ public class KakaoPayService {
             Payment payment = Payment.builder()
                     .orderId(orderId)
                     .tid(pending.getTid())
+                    .pgTid(body.getTid())
                     .user(user)
                     .course(course)
                     .amount(approvedAmount)
+                    .method(PaymentMethod.KAKAOPAY)
                     .status(PaymentStatus.APPROVED)
-                    .paymentDate(approvedAt)
+                    .paymentDate(approvedAt)              // 결제일(표시용)
+                    .approvedAt(approvedAt)               //  승인일도 저장
                     .build();
             paymentRepository.save(payment);
         }


### PR DESCRIPTION
- PaymentRepository에 사용자 승인 결제 조회 쿼리 추가
  - findApprovedByUserIdWithCourse(userId): 결제 + 코스 join fetch, 결제일 desc 정렬
- AuthService에 PaymentRepository 주입
- getMyPageInfo()를 readOnly 트랜잭션으로 전환하고, 승인 결제 목록을 PaymentDto(courseId, courseName, price, paymentDate)로 매핑해 반환
- (임시) coursesProgress는 기존대로 빈 리스트 유지

refactor: 불필요한 빈 리스트 생성 로직 정리 및 스트림 변환 적용
docs: 마이페이지 응답에 payments가 채워지려면 Payment.status=APPROVED, paymentDate가 세팅돼 있어야 함을 주석으로 명시