### PR TITLE
feat(lecture): durationSec/sizeBytes 수신·저장·응답 + Swagger 정리

### DIFF
--- a/src/main/java/com/example/ei_backend/domain/dto/lecture/LectureCreateRequest.java
+++ b/src/main/java/com/example/ei_backend/domain/dto/lecture/LectureCreateRequest.java
@@ -24,5 +24,6 @@ public class LectureCreateRequest {
     private Boolean isPublic;
 
     private Integer durationSec;
+    private Long sizeBytes;
 
 }

--- a/src/main/java/com/example/ei_backend/domain/dto/lecture/LectureDetailDto.java
+++ b/src/main/java/com/example/ei_backend/domain/dto/lecture/LectureDetailDto.java
@@ -1,6 +1,10 @@
 package com.example.ei_backend.domain.dto.lecture;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
+
+import lombok.*;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Getter
 @Setter
@@ -8,13 +12,24 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class LectureDetailDto {
-
     private Long id;
-    private Long courseId;
     private String title;
+    private Long courseId;
     private String description;
-    private Integer durationSec;
-    private String videoUrl;
-    private double progress;
+    private int orderIndex;
 
+    @JsonProperty("isPublic")
+    private boolean isPublic;
+
+    @Schema(description = "영상 길이(초)")
+    private Integer durationSec;
+
+    @Schema(description = "영상 URL(READY 상태일 때만)")
+    private String videoUrl;
+
+    @Schema(description = "영상 파일 크기(바이트)")
+    private Long sizeBytes;
+
+    @Schema(description = "해당 강의 진행도(%) 또는 상대값")
+    private Double progress;
 }

--- a/src/main/java/com/example/ei_backend/domain/dto/lecture/LectureSummaryDto.java
+++ b/src/main/java/com/example/ei_backend/domain/dto/lecture/LectureSummaryDto.java
@@ -1,5 +1,6 @@
 package com.example.ei_backend.domain.dto.lecture;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 @Getter
@@ -12,6 +13,10 @@ public class LectureSummaryDto {
     private Long id;
     private String title;
     private int orderIndex;
+
+    @JsonProperty("isPublic")   // 응답 키를 isPublic로 고정
+    private boolean isPublic;
+
     private int durationSec;
     private double progress;
 

--- a/src/main/java/com/example/ei_backend/domain/dto/lecture/LectureUpdateRequest.java
+++ b/src/main/java/com/example/ei_backend/domain/dto/lecture/LectureUpdateRequest.java
@@ -16,5 +16,6 @@ public class LectureUpdateRequest {
     private Integer orderIndex;
     private Boolean isPublic;
     private Integer durationSec;
+    private Long sizeBytes;
 
 }

--- a/src/main/java/com/example/ei_backend/domain/entity/Lecture.java
+++ b/src/main/java/com/example/ei_backend/domain/entity/Lecture.java
@@ -73,8 +73,7 @@ public class Lecture extends BaseTimeEntity {
         this.durationSec = 0; }
     }
 
-
     public void updateDurationFromVideo(int sec) {
-        this.durationSec = Math.max(0, sec);
+        if (sec > 0) this.durationSec = sec;
     }
 }

--- a/src/main/java/com/example/ei_backend/mapper/LectureMapper.java
+++ b/src/main/java/com/example/ei_backend/mapper/LectureMapper.java
@@ -17,14 +17,16 @@ public interface LectureMapper {
     @Mapping(target = "orderIndex", source = "e.orderIndex")
     @Mapping(target = "durationSec", source = "e.durationSec")
     @Mapping(target = "progress", expression = "java(progress)")
+    @Mapping(target = "isPublic", expression = "java(e.isPublic())")
     LectureSummaryDto toSummary(Lecture e, double progress);
 
     @Mapping(target = "id", source = "e.id")
-    @Mapping(target = "courseId", source = "e.course.id")
     @Mapping(target = "title", source = "e.title")
     @Mapping(target = "description", source = "e.description")
     @Mapping(target = "durationSec", source = "e.durationSec")
+    @Mapping(target = "isPublic", expression = "java(e.isPublic())")
     @Mapping(target = "videoUrl", expression = "java(videoUrl)")
     @Mapping(target = "progress", expression = "java(progress)")
+    @Mapping(target = "sizeBytes", expression = "java(e.getVideo() != null ? e.getVideo().getSizeBytes() : null)")
     LectureDetailDto toDetail(Lecture e, String videoUrl, double progress);
 }

--- a/src/main/java/com/example/ei_backend/testadmin/TestDataInitializer.java
+++ b/src/main/java/com/example/ei_backend/testadmin/TestDataInitializer.java
@@ -7,6 +7,8 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.List;
+
 @Configuration
 @RequiredArgsConstructor
 public class TestDataInitializer {
@@ -16,17 +18,43 @@ public class TestDataInitializer {
     @Bean
     public CommandLineRunner initCourseData() {
         return args -> {
-            if (courseRepository.count() == 0) {
-                Course course = Course.builder()
-                        .title("동철코딩 백엔드 강의")
-                        .description("실전 프로젝트 백엔드 강의")
-                        .price(990000)
-                        .imageUrl("https://my-project-bucket.s3.ap-northeast-2.amazonaws.com/sample.jpg")
-                        .build();
+            // 이미 데이터가 있으면 아무 것도 안 함 (중복 insert 방지)
+            if (courseRepository.count() > 0) return;
 
-                courseRepository.save(course);
-                System.out.println(" 테스트용 Course 등록 완료");
-            }
+            List<Course> courses = List.of(
+                    Course.builder()
+                            .title("DATA AI")
+                            .description("데이터 분석 · 머신러닝 · MLOps 핵심 커리큘럼")
+                            .price(219)
+                            .imageUrl(cdn("/images/courses/data-ai.jpg"))
+                            .build(),
+                    Course.builder()
+                            .title("풀스택")
+                            .description("프론트엔드 + 백엔드 풀스택 실전 프로젝트")
+                            .price(259)
+                            .imageUrl(cdn("/images/courses/fullstack.jpg"))
+                            .build(),
+                    Course.builder()
+                            .title("프론트엔드")
+                            .description("React 기반 웹 프론트엔드 심화")
+                            .price(179)
+                            .imageUrl(cdn("/images/courses/frontend.jpg"))
+                            .build(),
+                    Course.builder()
+                            .title("백엔드")
+                            .description("Java/Spring Boot 백엔드 핵심 & 실전")
+                            .price(199)
+                            .imageUrl(cdn("/images/courses/backend.jpg"))
+                            .build()
+            );
+
+            courseRepository.saveAll(courses);
+            System.out.println("▶ 초기 코스 4개 등록 완료 (DATA AI / 풀스택 / 프론트엔드 / 백엔드)");
         };
+    }
+
+    private static String cdn(String path) {
+        // CDN을 쓰지 않으면 S3 경로로 바꿔도 됩니다.
+        return "https://cdn.dongcheolcoding.life" + path;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,7 +49,7 @@
 
       jpa:
         hibernate:
-          ddl-auto: update
+          ddl-auto: create
         show-sql: true
         properties:
           hibernate.format_sql: true


### PR DESCRIPTION
- Controller
  - (admin) 멀티파트 생성/수정 엔드포인트의 `data` 파라미터를 JSON 문자열로 받도록 명시
  - Swagger에 `@ExampleObject` 추가: durationSec, sizeBytes 포함한 예시 JSON 제공
  - 엔드포인트/컨텐츠타입은 그대로 유지 (multipart/form-data)

- DTO
  - LectureCreateRequest, LectureUpdateRequest에 `durationSec`, `sizeBytes` 필드 추가

- Service(LectureCreateWithVideoService)
  - create(): 영상 파일이 없어도 `durationSec`이 오면 강의에 반영
  - create()/update(): `sizeBytes`는 요청값 우선, 없으면 업로드 파일 크기 사용
  - update(): 새 영상 업로드 시/미업로드 시 모두 `durationSec` 동기화 보장
  - 기존 VideoAsset가 있을 때도 강의의 `durationSec` 갱신

- Mapper(LectureMapper)
  - LectureDetailDto 매핑에 `sizeBytes` 추가
  - LectureSummaryDto/DetailDto에 `isPublic` 필드 매핑 보강
  - 불필요한 `courseId` 매핑 제거(빌더 프로퍼티 불일치 컴파일 에러 해결)

- API 응답
  - Detail/Summary 응답에 `isPublic` 정확히 노출(이전 `public` 키 문제 해결)
  - Detail 응답에 `sizeBytes` 포함

BREAKING CHANGE:
- 응답 JSON 키 중 공개여부는 `isPublic`으로 고정됩니다.