### PR TITLE
feat(auth): 이메일 회원가입/로그인 흐름 분리 및 성공/실패 페이지 분리

### DIFF
--- a/src/main/java/com/example/ei_backend/config/AppConfig.java
+++ b/src/main/java/com/example/ei_backend/config/AppConfig.java
@@ -1,0 +1,10 @@
+package com.example.ei_backend.config;
+
+import com.example.ei_backend.util.AppFrontProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@EnableConfigurationProperties(AppFrontProperties.class)
+@Configuration
+public class AppConfig {
+}

--- a/src/main/java/com/example/ei_backend/config/Configuration.java
+++ b/src/main/java/com/example/ei_backend/config/Configuration.java
@@ -1,0 +1,14 @@
+package com.example.ei_backend.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
+
+@org.springframework.context.annotation.Configuration
+public class Configuration {
+
+    @Bean
+    RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+}

--- a/src/main/java/com/example/ei_backend/service/KakaoPayService.java
+++ b/src/main/java/com/example/ei_backend/service/KakaoPayService.java
@@ -6,6 +6,7 @@ import com.example.ei_backend.domain.dto.KakaoPayReadyRequestDto;
 import com.example.ei_backend.domain.dto.KakaoPayReadyResponseDto;
 import com.example.ei_backend.domain.entity.*;
 import com.example.ei_backend.repository.*;
+import com.example.ei_backend.util.AppFrontProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,23 +14,20 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.util.Map;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 @RequiredArgsConstructor
@@ -41,6 +39,9 @@ public class KakaoPayService {
     private final UserCourseRepository userCourseRepository;
     private final PendingPaymentRepository pendingPaymentRepository;
     private final PaymentRepository paymentRepository;
+    private final AppFrontProperties frontProps;
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
 
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
     private static final DateTimeFormatter ISO_LOCAL = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
@@ -54,11 +55,15 @@ public class KakaoPayService {
 //    @Value("${app.client.host}")
 //    private String clientHost;
 
-    @Value("${app.front.success-url}")
-    private String frontSuccessUrl;
+/*
+    @Value("${app.front.payment.success-url:${app.front.success-url:}}")
+    private String paymentSuccessUrl;
+*/
 
+/*
     @Value("${app.client.host}") // 예: https://api.dongcheolcoding.life
     private String apiBaseUrl;
+*/
 
 
     @Transactional
@@ -67,21 +72,30 @@ public class KakaoPayService {
             var user = userRepository.findByEmail(userEmail)
                     .orElseThrow(() -> new IllegalStateException("사용자 없음"));
 
-            // ✅ 이미 수강 중이면 Ready 자체를 차단
+            // 이미 보유 차단
             if (userCourseRepository.existsByUserIdAndCourseId(user.getId(), course.getId())) {
                 throw new IllegalStateException("이미 결제(수강)한 코스입니다.");
             }
 
-            HttpHeaders headers = new HttpHeaders();
-            headers.setContentType(MediaType.APPLICATION_JSON);
-            headers.set("Authorization", "SECRET_KEY " + kakaoPaySecretKey);
+            // 필수 URL 확보
+            var successUrl = Optional.ofNullable(frontProps.getPayment().getSuccessUrl())
+                    .filter(u -> u.startsWith("https://"))
+                    .orElseThrow(() -> new IllegalStateException("HTTPS 결제 성공 URL이 필요합니다"));
+            var failUrl = Optional.ofNullable(frontProps.getPayment().getFailUrl())
+                    .filter(u -> u.startsWith("https://"))
+                    .orElseThrow(() -> new IllegalStateException("HTTPS 결제 실패 URL이 필요합니다"));
 
             String orderId = UUID.randomUUID().toString();
             String approvalUrlWithOrderId = UriComponentsBuilder
-                    .fromHttpUrl(frontSuccessUrl)
+                    .fromUriString(successUrl)
                     .queryParam("orderId", orderId)
                     .build(true)
                     .toUriString();
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.set("Authorization", "SECRET_KEY " + kakaoPaySecretKey);
+            headers.setAccept(java.util.List.of(MediaType.APPLICATION_JSON));
 
             KakaoPayReadyRequestDto request = KakaoPayReadyRequestDto.builder()
                     .cid(cid)
@@ -93,16 +107,17 @@ public class KakaoPayService {
                     .taxFreeAmount(0)
                     .vatAmount(course.getPrice() / 10)
                     .approvalUrl(approvalUrlWithOrderId)
-                    .cancelUrl(apiBaseUrl + "/api/payment/cancel")
-                    .failUrl(apiBaseUrl + "/api/payment/fail")
+                    // A안(프론트 직접 이동): 아래 두 줄
+                    .cancelUrl(failUrl + "?reason=cancelled")
+                    .failUrl(failUrl + "?reason=failed")
+                    // B안(API 경유 이동)으로 하려면 위 두 줄 대신 기존처럼 apiBaseUrl + "/api/payment/..." 사용
                     .build();
 
             var entity = new HttpEntity<>(request, headers);
-            var rawResponse = new RestTemplate().postForEntity(
+            var rawResponse = restTemplate.postForEntity(
                     "https://open-api.kakaopay.com/online/v1/payment/ready",
                     entity, String.class);
 
-            var objectMapper = new ObjectMapper();
             var res = objectMapper.readValue(rawResponse.getBody(), KakaoPayReadyResponseDto.class);
 
             pendingPaymentRepository.save(
@@ -119,15 +134,13 @@ public class KakaoPayService {
             return res;
 
         } catch (HttpClientErrorException | HttpServerErrorException e) {
-            log.error(" [카카오 오류 응답] 상태코드: {}", e.getStatusCode());
-            log.error(" [카카오 오류 응답 본문] {}", e.getResponseBodyAsString());
-            throw new RuntimeException("카카오 API 오류: " + e.getMessage());
+            log.error("[KAKAO][READY] status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new RuntimeException("카카오 API 오류: " + e.getMessage(), e);
         } catch (Exception e) {
-            log.error(" [예상치 못한 에러]", e);
+            log.error("[KAKAO][READY] 예상치 못한 에러", e);
             throw new RuntimeException("카카오페이 ready 요청 중 오류 발생", e);
         }
     }
-
 
     @Transactional
     public String approve(String orderId, String pgToken, String userEmail, Long userId) {
@@ -140,7 +153,7 @@ public class KakaoPayService {
             return "{\"message\":\"already approved\"}";
         }
 
-        // ✅ 승인 호출 직전, 다시 보유 여부 점검
+        //  승인 호출 직전, 다시 보유 여부 점검
         var user = userRepository.findByEmail(userEmail)
                 .orElseThrow(() -> new IllegalStateException("사용자 없음"));
         var course = courseRepository.findById(pending.getCourseId())
@@ -162,7 +175,7 @@ public class KakaoPayService {
                 .pgToken(pgToken)
                 .build();
 
-        var resp = new RestTemplate().postForEntity(
+        var resp = restTemplate.postForEntity(
                 "https://open-api.kakaopay.com/online/v1/payment/approve",
                 new HttpEntity<>(req, headers),
                 KakaoPayApproveResponseDto.class

--- a/src/main/java/com/example/ei_backend/util/AppFrontProperties.java
+++ b/src/main/java/com/example/ei_backend/util/AppFrontProperties.java
@@ -1,0 +1,17 @@
+package com.example.ei_backend.util;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.front")
+@Getter
+@Setter
+public class AppFrontProperties {
+    private Email email = new Email();
+    private Oauth oauth = new Oauth();
+    private Payment payment = new Payment();
+    @Getter @Setter public static class Email { private String successUrl; private String failUrl; }
+    @Getter @Setter public static class Oauth { private String successUrl; private String failUrl; }
+    @Getter @Setter public static class Payment { private String successUrl; private String failUrl; }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,14 +72,28 @@
     app:
       client:
         host: ${CLIENT_HOST}
+
       cookie:
-        root-domain: ${COOKIE_DOMAIN:}
-        secure: ${COOKIE_SECURE:false}
-        same-site: ${COOKIE_SAMESITE:Lax}
-        max-days: 14
+        root-domain: ${COOKIE_DOMAIN:}     # prod: dongcheolcoding.life, local: 빈 값
+        secure: ${COOKIE_SECURE:false}     # prod: true(HTTPS), local: false
+        same-site: ${COOKIE_SAMESITE:Lax}  # Lax/Strict/None (None이면 secure=true 필수)
+        max-days: 14                       # RT 유효일수
+
       front:
-        success-url: ${FRONT_SUCCESS_URL:https://dongcheolcoding.life/course/kakaopay}
+        email:
+          success-url: https://dongcheolcoding.life/auth/verify-success
+          fail-url: https://dongcheolcoding.life/auth/verify-fail
+
+      oauth:
+        success-url: https://dongcheolcoding.life/account/kakaoauth
+        fail-url: https://dongcheolcoding.life/auth/kakao-fail
+
+      payment:
+        success-url: https://dongcheolcoding.life/course/kakaopay/success
+        fail-url: https://dongcheolcoding.life/course/kakaopay/fail
+
       cdn-base-url: ${CDN_BASE_URL:https://cdn.dongcheolcoding.life}
+
       seed:
         enabled: false
 


### PR DESCRIPTION
- 이메일 회원가입 시 인증 메일 발송 및 인증 코드 검증 후 최종 가입 처리
- 이메일 인증 성공 시 access/refresh token 쿠키 발급 후 이메일 전용 success 페이지로 리다이렉트
- 실패 시 별도 이메일 실패 페이지로 이동
- 카카오 소셜 로그인 성공 페이지와 URL 분리 (혼동 제거)

feat(payment): 카카오페이 결제 모듈 분리 및 안정화
- KakaoPayService 리팩토링
  - RestTemplate, ObjectMapper Bean 주입으로 변경
  - success/fail URL AppFrontProperties로 관리
  - approvalUrl에 orderId 파라미터 부여
  - cancel/fail 시 프론트 전용 페이지로 직접 리다이렉트
- Ready 시 기존 수강 여부 확인 → 중복 결제 차단
- Approve 시 보유 여부/금액 일치/멱등성 검증 강화
- 결제 시간(approvedAt) 파싱 시 OffsetDateTime → KST 변환 처리
- 결제 PendingPayment/Payment/수강(UserCourse) 저장 로직 안정화

refactor(config): application.yml front 설정 정리
- app.front.email.success-url / fail-url 추가
- app.front.payment.success-url / fail-url 추가
- app.front.oauth.success-url / fail-url 분리
- 각 서비스에서 AppFrontProperties 통해 URL 참조

chore: 불필요한 레거시 키 제거 및 코드 정리
- app.front.success-url 레거시 프로퍼티 삭제
- KakaoPayService 내 paymentSuccessUrl 필드 제거
- 미사용 import 및 주석 제거