### PR TITLE
fix(signup): 이메일 인증 시 사용자 영속화 누락 수정

### DIFF
--- a/src/main/java/com/example/ei_backend/controller/AuthController.java
+++ b/src/main/java/com/example/ei_backend/controller/AuthController.java
@@ -27,6 +27,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -46,6 +47,7 @@ import java.util.Optional;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
+@Slf4j
 public class AuthController {
 
     private final AuthService authService;
@@ -110,6 +112,7 @@ public class AuthController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된/만료된 코드"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이미 인증됨")
     })
+
     @GetMapping("/verify")
     public void verifyByEmailLink(
             @RequestParam String email,
@@ -137,11 +140,12 @@ public class AuthController {
             res.addHeader(HttpHeaders.SET_COOKIE, atCookie.toString());
             res.addHeader(HttpHeaders.SET_COOKIE, rtCookie.toString());
 
-            //  이메일 인증 전용 성공 페이지로 이동
             res.sendRedirect(emailVerifySuccessUrl);
         } catch (CustomException ex) {
-            //  이메일 인증 전용 실패 페이지로 이동
             res.sendRedirect(emailVerifyFailUrl + "?reason=" + ex.getErrorCode().name());
+        } catch (RuntimeException ex) {
+             log.error("[VERIFY] unexpected", ex);
+            res.sendRedirect(emailVerifyFailUrl + "?reason=SERVER_ERROR");
         }
     }
 

--- a/src/main/java/com/example/ei_backend/domain/entity/EmailVerification.java
+++ b/src/main/java/com/example/ei_backend/domain/entity/EmailVerification.java
@@ -18,11 +18,13 @@ public class EmailVerification {
     @Column(name = "email_verification_id")
     private Long id;
 
+    @Column(nullable = false)
     private String email;
 
+    @Column(nullable = false)
     private String code;
 
-    @Column(name = "expiration_time")
+    @Column(name="expiration_time", nullable = false)
     private LocalDateTime expirationTime;
 
     @Builder.Default
@@ -33,7 +35,6 @@ public class EmailVerification {
     @Column(name = "request_data")
     private String requestData;
 
-    @Builder
     public EmailVerification(String email, String code, LocalDateTime expirationTime) {
         this.email = email;
         this.code = code;

--- a/src/main/java/com/example/ei_backend/exception/ErrorCode.java
+++ b/src/main/java/com/example/ei_backend/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     SERVER_ERROR("E500", HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
     INVALID_ROLE("E400", HttpStatus.BAD_REQUEST, "유효하지 않은 사용자 역할입니다."),
     CONFLICT("E409", HttpStatus.CONFLICT, "리소스 충돌"),
+    DATABASE_CONSTRAINT_VIOLATION("E409_DB", HttpStatus.BAD_REQUEST, "데이터 무결성 위반"),
 
     // 회원/인증
     EMAIL_ALREADY_EXISTS("U409", HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
@@ -23,6 +24,7 @@ public enum ErrorCode {
     USER_NOT_FOUND("U404", HttpStatus.NOT_FOUND, "존재하지 않는 사용자"),
     INVALID_CREDENTIALS("U401", HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 잘못되었습니다."),
     PROFILE_IMAGE_NOT_FOUND("U404", HttpStatus.NOT_FOUND, "프로필 이미지가 없습니다."),
+
 
     // 강의 / 결제
     COURSE_NOT_FOUND("C404", HttpStatus.NOT_FOUND, "강의를 찾을 수 없습니다."),

--- a/src/main/java/com/example/ei_backend/repository/EmailVerificationRepository.java
+++ b/src/main/java/com/example/ei_backend/repository/EmailVerificationRepository.java
@@ -3,10 +3,19 @@ package com.example.ei_backend.repository;
 import com.example.ei_backend.domain.entity.EmailVerification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
     Optional<EmailVerification> findByEmail(String email);
     Optional<EmailVerification> findTopByEmailOrderByExpirationTimeDesc(String email);
     Optional<EmailVerification> findByCode(String code);
+
+    // 특정 코드가 해당 이메일의 “유효한” 코드인지 한 번에 판단
+    Optional<EmailVerification> findByEmailAndCodeAndExpirationTimeAfter(String email, String code, LocalDateTime now);
+
+    // (code만으로 처리하는 오버로드를 유지하려면) 코드+만료안됨
+    Optional<EmailVerification> findByCodeAndExpirationTimeAfter(
+            String code, LocalDateTime now
+    );
 }


### PR DESCRIPTION
AuthService.verifyAndSignup(email, code)에서

findByEmailAndCodeAndExpirationTimeAfter(...)로 만료/코드 동시 검증

verification.verify(code)로 상태 전이(멱등/만료/불일치 처리)

userRepository.saveAndFlush(user)로 즉시 제약 위반 표면화

DataIntegrityViolationException 잡아서 DATABASE_CONSTRAINT_VIOLATION로 래핑

feat(repo): EmailVerification 쿼리 추가

findByEmailAndCodeAndExpirationTimeAfter(String email, String code, LocalDateTime now)

findByCodeAndExpirationTimeAfter(String code, LocalDateTime now) (code-전용 링크 사용 시)

feat(entity): EmailVerification 도메인 메서드/필드 정비

verify(String inputCode) 도메인 로직(중복/만료/불일치)

@Getter로 isVerified(), getEmail() 제공

(옵션) verifiedAt 필드 추가 가능

@Builder 중복 제거

fix(controller): 이메일 인증 실패 분기 보강

catch (CustomException) → 실패 페이지 리다이렉트(reason 쿼리)

catch (RuntimeException) 추가 → 일반 오류도 실패 페이지로 안전하게 유도