### PR TITLE
feat(payment/kakaopay): Ready/Approve 안정화 및 HTTPS 규칙(로컬 예외) 적용

### DIFF
--- a/src/main/java/com/example/ei_backend/EiBackendApplication.java
+++ b/src/main/java/com/example/ei_backend/EiBackendApplication.java
@@ -2,10 +2,12 @@ package com.example.ei_backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@ConfigurationPropertiesScan(basePackages = "com.example.ei_backend")
 public class EiBackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/ei_backend/config/Configuration.java
+++ b/src/main/java/com/example/ei_backend/config/Configuration.java
@@ -4,11 +4,16 @@ import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.Duration;
+
 @org.springframework.context.annotation.Configuration
 public class Configuration {
 
     @Bean
     RestTemplate restTemplate(RestTemplateBuilder builder) {
-        return builder.build();
+        return builder
+                .setConnectTimeout(Duration.ofSeconds(5))
+                .setReadTimeout(Duration.ofSeconds(10))
+                .build();
+        }
     }
-}


### PR DESCRIPTION
KakaoPayService

AppFrontProperties에서 결제 successUrl/failUrl 주입

로컬(http://localhost/127.0.0.1)만 HTTP 허용, 그 외 환경은 HTTPS 강제

approvalUrl에 orderId 쿼리파라미터 부착

cancelUrl/failUrl을 프론트 URL로 구성(?reason=...)

RestTemplate/ObjectMapper 주입 사용 (생성/정적 호출 제거)

Kakao 응답을 DTO로 역직렬화하고, 예외/널 응답 방어 강화

PendingPayment 저장(READY), 금액/소유자/멱등성 검증 후 Payment/UserCourse 생성(approve)

KST 기준 승인 시간 파싱(오프셋 문자열/로컬 포맷 모두 지원)

상세 로그: [KAKAO][READY], [KakaoPay][APPROVE]

Configuration

RestTemplate 빈 등록

(권장) 타임아웃 설정 예시 주석 추가

application.yml

app.front.payment.success-url/fail-url 설정 사용

kakaopay.api.* 환경변수 경로 명확화