### PR TITLE
feat(auth): 로그아웃을 토큰 만료와 무관하게 동작하도록(idempotent) + CookieUtils/Reposit…

### DIFF
--- a/src/main/java/com/example/ei_backend/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/ei_backend/repository/RefreshTokenRepository.java
@@ -22,4 +22,7 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Stri
 
     @Transactional
     long deleteByEmail(String email);
+
+    @Transactional
+    void deleteByToken(String token);
 }

--- a/src/main/java/com/example/ei_backend/security/SecurityConfig.java
+++ b/src/main/java/com/example/ei_backend/security/SecurityConfig.java
@@ -93,6 +93,7 @@ public class SecurityConfig {
 
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/course", "/api/course/").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/auth/logout").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/payment/cancel", "/api/payment/fail").permitAll()
                         // 프로필 이미지는 인증 필수
                         .requestMatchers(HttpMethod.PATCH,  "/api/auth/profile/image").authenticated()

--- a/src/main/java/com/example/ei_backend/service/AuthService.java
+++ b/src/main/java/com/example/ei_backend/service/AuthService.java
@@ -33,6 +33,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -180,6 +181,18 @@ public class AuthService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         user.validatePassword(newPassword, passwordEncoder);
+    }
+
+    @Transactional
+    public void logout(String email, String refreshToken) {
+        if (StringUtils.hasText(email)) {
+            refreshTokenRepository.deleteByEmail(email);
+            return;
+        }
+        if (StringUtils.hasText(refreshToken)) {
+            refreshTokenRepository.deleteByToken(refreshToken);
+        }
+
     }
 
 

--- a/src/main/java/com/example/ei_backend/util/CookieUtils.java
+++ b/src/main/java/com/example/ei_backend/util/CookieUtils.java
@@ -1,8 +1,12 @@
 package com.example.ei_backend.util;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseCookie;
 
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.Optional;
 
 public class CookieUtils {
 
@@ -53,5 +57,21 @@ public class CookieUtils {
         }
         return b.build();
     }
+
+    /** 요청에서 특정 이름의 쿠키를 Optional로 반환 (null-safe) */
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        if (request == null || request.getCookies() == null || name == null) {
+            return Optional.empty();
+        }
+        return Arrays.stream(request.getCookies())
+                .filter(c -> name.equals(c.getName()))
+                .findFirst();
+    }
+
+    /** 값이 바로 필요할 때 편의용 (없으면 null) */
+    public static String getCookieValue(HttpServletRequest request, String name) {
+        return getCookie(request, name).map(Cookie::getValue).orElse(null);
+    }
+
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,6 @@
           max-file-size: 200MB
           max-request-size: 200MB
       server:
-        forward-headers-strategy: native
         tomcat:
           max-swallow-size: -1
       security:
@@ -74,23 +73,21 @@
         host: ${CLIENT_HOST}
 
       cookie:
-        root-domain: ${COOKIE_DOMAIN:}     # prod: dongcheolcoding.life, local: 빈 값
-        secure: ${COOKIE_SECURE:false}     # prod: true(HTTPS), local: false
-        same-site: ${COOKIE_SAMESITE:Lax}  # Lax/Strict/None (None이면 secure=true 필수)
-        max-days: 14                       # RT 유효일수
+        root-domain: ${COOKIE_DOMAIN:}
+        secure: ${COOKIE_SECURE:false}
+        same-site: ${COOKIE_SAMESITE:Lax}
+        max-days: 14
 
       front:
         email:
           success-url: https://dongcheolcoding.life/auth/verify-success
           fail-url: https://dongcheolcoding.life/auth/verify-fail
-
-      oauth:
-        success-url: https://dongcheolcoding.life/account/kakaoauth
-        fail-url: https://dongcheolcoding.life/auth/kakao-fail
-
-      payment:
-        success-url: https://dongcheolcoding.life/course/kakaopay/success
-        fail-url: https://dongcheolcoding.life/course/kakaopay/fail
+        oauth:
+          success-url: https://dongcheolcoding.life/account/kakaoauth
+          fail-url: https://dongcheolcoding.life/auth/kakao-fail
+        payment:
+          success-url: https://dongcheolcoding.life/course/kakaopay/success
+          fail-url: https://dongcheolcoding.life/course/kakaopay/fail
 
       cdn-base-url: ${CDN_BASE_URL:https://cdn.dongcheolcoding.life}
 


### PR DESCRIPTION
…ory 보강

- 컨트롤러
  - POST /api/auth/logout: principal null 허용, RT를 쿠키에서 직접 읽어 서버측 정리 시도
  - AT/RT/JSESSIONID 쿠키 항상 삭제, SecurityContext clear + 세션 무효화
  - 204 No Content 반환(예외는 best-effort로 로깅)

- 유틸
  - CookieUtils.getCookie/getCookieValue 추가 (null-safe Optional/편의 메서드)

- 리포지토리/서비스
  - RefreshTokenRepository: deleteByEmail, deleteByToken 추가
  - AuthService.logout(email, refreshToken): 우선순위 email → refreshToken, 값 없으면 무해 통과

- 시큐리티
  - POST /api/auth/logout permitAll
  - CSRF 사용 시 /api/auth/logout 예외 처리

UX: AT가 만료된 상태에서도 로그아웃이 항상 성공하도록 보장(멱등성), 재발급 차단은 RT 삭제로 처리.

+ 카카오페이 URL 서버 버그 픽스