### PR TITLE
feat(payment): 카카오 결제 서버 콜백 승인 플로우 도입 및 설정 정리

### DIFF
--- a/src/main/java/com/example/ei_backend/security/SecurityConfig.java
+++ b/src/main/java/com/example/ei_backend/security/SecurityConfig.java
@@ -94,6 +94,7 @@ public class SecurityConfig {
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/course", "/api/course/").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/auth/logout").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/payment/kakaopay/callback/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/payment/cancel", "/api/payment/fail").permitAll()
                         // 프로필 이미지는 인증 필수
                         .requestMatchers(HttpMethod.PATCH,  "/api/auth/profile/image").authenticated()

--- a/src/main/java/com/example/ei_backend/util/AppFrontProperties.java
+++ b/src/main/java/com/example/ei_backend/util/AppFrontProperties.java
@@ -8,6 +8,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Getter
 @Setter
 public class AppFrontProperties {
+
+    private String baseUrl;
+
     private Email email = new Email();
     private Oauth oauth = new Oauth();
     private Payment payment = new Payment();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -79,6 +79,7 @@
         max-days: 14
 
       front:
+        base-url: https://dongcheolcoding.life
         email:
           success-url: https://dongcheolcoding.life/auth/verify-success
           fail-url: https://dongcheolcoding.life/auth/verify-fail
@@ -137,9 +138,9 @@
         cid: TC0ONETIME
         secret:
           key: ${KAKAO_SECRET_KEY}
-        approval-url: https://api.dongcheolcoding.life/api/payment/approve
-        cancel-url: https://api.dongcheolcoding.life/api/payment/cancel
-        fail-url: https://api.dongcheolcoding.life/api/payment/fail
+#        approval-url: https://api.dongcheolcoding.life/api/payment/approve
+#        cancel-url: https://api.dongcheolcoding.life/api/payment/cancel
+#        fail-url: https://api.dongcheolcoding.life/api/payment/fail
 
 
 


### PR DESCRIPTION
- Controller
  - GET /api/payment/kakaopay/callback/success 추가(permitAll)
  - orderId/pg_token으로 approve 호출 후 프런트 도메인(baseUrl)으로 성공/실패 리다이렉트

- Service
  - ready(): 백엔드 콜백 approval_url 사용, orderId 생성 및 pending 저장
  - cancel/fail URL 안전 조립, itemName 길이 방어, 응답 검증 강화

- Config
  - AppFrontProperties.baseUrl 추가 및 yml(app.front.base-url) 반영
  - Security: 콜백·취소·실패 경로 permitAll, CSRF 비활성(현 설정 유지)

- Notes
  - kakaopay.api.* 프로퍼티는 현재 미사용 → 제거하거나 코드에서 참조하도록 정리 필요