### PR TITLE
feat(progress): 코스 진행률 집계 추가 및 마이페이지 응답 개선

### DIFF
--- a/src/main/java/com/example/ei_backend/domain/dto/CourseDto.java
+++ b/src/main/java/com/example/ei_backend/domain/dto/CourseDto.java
@@ -61,9 +61,9 @@ public class CourseDto {
         private Long courseId;
         private String courseTitle;
         private String imageUrl;
-        private double progress;     // 0.0~1.0
         private int completedCount;
         private int totalCount;
+        private CourseProgressDto progress;
     }
 
     // 심플한 페이지 래퍼 (ApiResponse 안에 또 Page 쓰는 게 싫다면 이렇게)

--- a/src/main/java/com/example/ei_backend/domain/dto/CourseProgressDto.java
+++ b/src/main/java/com/example/ei_backend/domain/dto/CourseProgressDto.java
@@ -1,13 +1,27 @@
 package com.example.ei_backend.domain.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class CourseProgressDto {
-    private String CourseName;
-    private int completePercent;
+    private double progressPercent;     // 0.0 ~ 100.0
+    private long completedLectures;     // 완료 강의 수
+    private long totalLectures;         // 전체 강의 수
+    private boolean completed;          // 코스 완료 여부 (임계치 기반)
+
+    public static CourseProgressDto of(double percent, long completed, long total, double completeThreshold) {
+        boolean done = percent >= completeThreshold;
+        return CourseProgressDto.builder()
+                .progressPercent(Math.round(percent * 10.0) / 10.0) // 소수점 1자리 반올림
+                .completedLectures(completed)
+                .totalLectures(total)
+                .completed(done)
+                .build();
+    }
 }

--- a/src/main/java/com/example/ei_backend/repository/CourseRepository.java
+++ b/src/main/java/com/example/ei_backend/repository/CourseRepository.java
@@ -1,8 +1,13 @@
 package com.example.ei_backend.repository;
 
 import com.example.ei_backend.domain.entity.Course;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,4 +19,11 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
     boolean existsByTitle(String title);
     Optional<Course> findByIdAndPublishedTrueAndDeletedFalse(Long id);
 
+    @Query("""
+       select distinct c
+       from Course c
+       join UserCourse uc on uc.course.id = c.id
+       where uc.user.id = :userId
+    """)
+    Page<Course> findMyCourses(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/example/ei_backend/repository/LectureProgressRepository.java
+++ b/src/main/java/com/example/ei_backend/repository/LectureProgressRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -20,6 +21,30 @@ public interface LectureProgressRepository extends JpaRepository<LectureProgress
         where l.course.id = :courseId and lp.user.id = :userId and lp.completed = true
     """)
     long countCompletedLectures(@Param("userId") Long userId, @Param("courseId") Long courseId);
+
+    // 코스 단위 총 시청 시간 (각 강의별로 durationSec을 넘지 않도록 '캡핑' 후 합산)
+    @Query("""
+      select coalesce(
+        sum(case when lp.watchedSec > l.durationSec then l.durationSec else lp.watchedSec end)
+      , 0)
+      from LectureProgress lp
+      join lp.lecture l
+      where lp.user.id = :userId
+        and l.course.id = :courseId
+    """)
+    long sumWatchedCappedByUserAndCourse(@Param("userId") Long userId,
+                                         @Param("courseId") Long courseId);
+
+    // 강의별 누적 시청 시간 (per-lecture 진행률 화면이 필요할 때만 사용)
+    @Query("""
+      select lp.lecture.id, sum(lp.watchedSec)
+      from LectureProgress lp
+      where lp.user.id = :userId
+        and lp.lecture.course.id = :courseId
+      group by lp.lecture.id
+    """)
+    List<Object[]> sumWatchedByUserAndCourse(@Param("userId") Long userId,
+                                             @Param("courseId") Long courseId);
 
 }
 

--- a/src/main/java/com/example/ei_backend/service/CourseProgressService.java
+++ b/src/main/java/com/example/ei_backend/service/CourseProgressService.java
@@ -1,0 +1,37 @@
+package com.example.ei_backend.service;
+
+import com.example.ei_backend.repository.LectureProgressRepository;
+import com.example.ei_backend.repository.LectureRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CourseProgressService {
+
+    private final LectureRepository lectureRepository;
+    private final LectureProgressRepository lectureProgressRepository;
+
+    /** 코스 진행률 (0.0 ~ 100.0) */
+    public double getCourseProgressPercent(Long userId, Long courseId) {
+        long totalDuration = lectureRepository.sumDurationByCourseId(courseId);
+        if (totalDuration <= 0) return 0.0;
+
+        long watched = lectureProgressRepository
+                .sumWatchedCappedByUserAndCourse(userId, courseId);
+
+        return (double) watched / (double) totalDuration * 100.0;
+    }
+
+    /** 완료 강의 수 / 전체 강의 수 */
+    public ProgressCount getProgressCount(Long userId, Long courseId) {
+        long total = lectureRepository.countByCourseId(courseId);
+        long completed = lectureProgressRepository.countCompletedLectures(userId, courseId);
+        return new ProgressCount(total, completed);
+    }
+
+    public record ProgressCount(long totalLectures, long completedLectures) {}
+}
+


### PR DESCRIPTION
- LectureProgressRepository에 코스 단위 시청시간 집계 쿼리 추가
  - sumWatchedCappedByUserAndCourse(userId, courseId): 강의별 watchedSec을 durationSec으로 캡핑 후 합산
  - sumWatchedByUserAndCourse(userId, courseId): per-lecture 누적 시청시간(선택 사용)
  - countCompletedLectures(userId, courseId): 완료 강의 수 집계

- CourseProgressService 신규
  - getCourseProgressPercent(userId, courseId): 코스 전체 진행률(0~100) 계산
  - getProgressCount(userId, courseId): 완료/전체 강의 수 리턴

- DTO 확장
  - CourseProgressDto: { progressPercent, completedLectures, totalLectures, completed } 추가
  - CourseDto.MyCourseItem: progress 타입을 double → CourseProgressDto로 교체 (불필요한 completedCount/totalCount, double progress 제거)

- 내 코스 목록 API 개선
  - CourseService.findMyCourses(): UserCourse 기반 목록에서 코스 단위 진행률 계산 적용
  - 응답에 CourseProgressDto 포함
  - app.progress.complete-threshold(기본 90.0) 적용

- 정리/리팩터링
  - 필드명 정합성(c.courseTitle vs courseName) 맞춤
  - JPA/JPQL 경고 제거(count(1) 공백 제거 등)