### PR TITLE
ready()에서 approvalUrl을 프론트 성공 페이지(…/course/kakaopay/success?orderId=……

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,6 +78,9 @@
         same-site: ${COOKIE_SAMESITE:Lax}
         max-days: 14
 
+      api:
+        base-url: https://api.dongcheolcoding.life
+
       front:
         base-url: https://dongcheolcoding.life
         email:


### PR DESCRIPTION
…)로 보냄 → 카카오가 그 URL에 pg_token을 붙여 리다이렉트.

프론트는 orderId와 pg_token을 받아 **백엔드 /api/payment/approve**로 호출 → 백엔드가 승인 처리 후 DB 반영.

실패/취소 시에도 프론트 실패 페이지로 이동하도록 이미 구성됨 → OK.