### PR TITLE
feat(progress): 강의 시청 진도 업데이트 API 통합 및 코스 진행률 실시간 반영

### DIFF
--- a/src/main/java/com/example/ei_backend/domain/dto/lecture/ProgressUpdateRequest.java
+++ b/src/main/java/com/example/ei_backend/domain/dto/lecture/ProgressUpdateRequest.java
@@ -12,7 +12,10 @@ import lombok.Setter;
 @AllArgsConstructor
 public class ProgressUpdateRequest {
 
+
     @NotNull
     private Integer watchedSec;
+
+    private boolean completed;
 
 }

--- a/src/main/java/com/example/ei_backend/domain/entity/LectureProgress.java
+++ b/src/main/java/com/example/ei_backend/domain/entity/LectureProgress.java
@@ -51,5 +51,27 @@ public class LectureProgress extends BaseTimeEntity {
         return changed;
     }
 
+    /** 시청 진행 업데이트(뒤로감기 방지 + 완료판정 + 정규화) */
+    public void applyProgress(int positionSec, int durationSec, double threshold, boolean clientCompleted) {
+        int dur = Math.max(1, durationSec);
+        int clamped = Math.max(this.watchedSec, Math.min(positionSec, dur)); // 뒤로감기 방지 + 캡핑
+        this.watchedSec = clamped;
+        this.lastPlayedAt = Instant.now();
+
+        double ratio = (double) this.watchedSec / dur;
+        if (clientCompleted || ratio >= threshold) {
+            this.completed = true;
+            this.watchedSec = dur; // ✅ 완료 시 정규화
+        }
+    }
+
+    /** 필요 시 외부에서 바로 완료 처리할 때 사용 */
+    public void markCompleted(int durationSec) {
+        int dur = Math.max(1, durationSec);
+        this.completed = true;
+        this.watchedSec = dur;
+        this.lastPlayedAt = Instant.now();
+    }
+
 
 }

--- a/src/main/java/com/example/ei_backend/service/LectureProgressService.java
+++ b/src/main/java/com/example/ei_backend/service/LectureProgressService.java
@@ -1,0 +1,39 @@
+package com.example.ei_backend.service;
+
+import com.example.ei_backend.domain.entity.LectureProgress;
+import com.example.ei_backend.domain.entity.User;
+import com.example.ei_backend.repository.LectureProgressRepository;
+import com.example.ei_backend.repository.LectureRepository;
+import com.example.ei_backend.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class LectureProgressService {
+
+    private final LectureRepository lectureRepository;
+    private final LectureProgressRepository lectureProgressRepository;
+    private final UserRepository userRepository; // ← 주입
+
+    @Value("${app.progress.complete-threshold-ratio:0.9}")
+    private double completeThresholdRatio;
+
+    @Transactional
+    public void updateProgress(Long userId, Long lectureId, int positionSec, boolean clientCompleted) {
+        var lecture = lectureRepository.getReferenceById(lectureId);
+        var userRef = userRepository.getReferenceById(userId);
+
+        var lp = lectureProgressRepository.findByUserIdAndLectureId(userId, lectureId)
+                .orElseGet(() -> LectureProgress.start(userRef, lecture));
+
+        lp.applyProgress(positionSec, lecture.getDurationSec(), completeThresholdRatio, clientCompleted);
+        lectureProgressRepository.save(lp);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,6 +72,10 @@
       client:
         host: ${CLIENT_HOST}
 
+      progress:
+        complete-threshold-ratio: 0.9   # 강의 완료 임계치(90%)
+        complete-threshold: 90.0
+
       cookie:
         root-domain: ${COOKIE_DOMAIN:}
         secure: ${COOKIE_SECURE:false}


### PR DESCRIPTION
- LectureProgress 엔티티 도메인 메서드 추가
  - start(user, lecture), updateWatched(...), applyProgress(...), markCompleted(...)
  - JPA 제약/인덱스: UNIQUE(user_id, lecture_id), idx(user_id), idx(lecture_id)
- LectureProgressService 구현
  - updateProgress(userId, lectureId, watchedSec, clientCompleted)
  - 완료 신호/임계치(complete-threshold-ratio) 반영, 완료 시 watchedSec=durationSec 정규화
- ProgressService 업데이트
  - 시그니처: update(userId, lectureId, watchedSec, clientCompleted)
  - LectureProgressService 위임 → 최신 LectureProgress 조회
  - CourseProgressService 연동(진행률 %, 완료/전체 수) 및 STOMP 브로드캐스트(/topic/progress/course/{courseId})
  - 불필요 필드/임포트 정리
- LectureController 정리
  - POST /api/lectures/{lectureId}/progress 단일화(@Valid)
  - 요청 DTO ProgressUpdateRequest { watchedSec(@NotNull), completed }
  - @PreAuthorize("isAuthenticated()") 적용
  - 중복 매핑 제거를 위해 LectureProgressController 삭제
- 설정
  - app.progress.complete-threshold-ratio=0.9, complete-threshold=90.0 추가

BREAKING CHANGE: 진행도 업데이트 요청 바디는 watchedSec 필드로 통일됨.