### PR TITLE
feat(course): /api/course/me 진행률 개편 및 코스 생성 시 이미지 파일 null 허용

### DIFF
--- a/src/main/java/com/example/ei_backend/domain/dto/CourseDto.java
+++ b/src/main/java/com/example/ei_backend/domain/dto/CourseDto.java
@@ -61,8 +61,6 @@ public class CourseDto {
         private Long courseId;
         private String courseTitle;
         private String imageUrl;
-        private int completedCount;
-        private int totalCount;
         private CourseProgressDto progress;
     }
 

--- a/src/main/java/com/example/ei_backend/repository/UserCourseRepository.java
+++ b/src/main/java/com/example/ei_backend/repository/UserCourseRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -14,4 +16,12 @@ public interface UserCourseRepository extends JpaRepository<UserCourse, Long> {
 
     @EntityGraph(attributePaths = "course")
     Page<UserCourse> findByUser_Id(Long userId, Pageable pageable);
+
+    @Query("""
+  select uc from UserCourse uc
+  join fetch uc.course c
+  where uc.user.id = :userId
+""")
+    Page<UserCourse> findByUser_IdWithCourse(@Param("userId") Long userId, Pageable pageable);
+
 }

--- a/src/main/java/com/example/ei_backend/service/CourseService.java
+++ b/src/main/java/com/example/ei_backend/service/CourseService.java
@@ -60,7 +60,7 @@ public class CourseService {
                 .build();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public Course findById(Long courseId) {
         return courseRepository.findById(courseId)
                 .orElseThrow(() -> new NotFoundException("course"));
@@ -111,7 +111,7 @@ public class CourseService {
     @Transactional(readOnly = true)
     public CourseDto.Page<CourseDto.MyCourseItem> findMyCourses(Long userId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
-        Page<UserCourse> result = userCourseRepository.findByUser_Id(userId, pageable);
+        Page<UserCourse> result = userCourseRepository.findByUser_IdWithCourse(userId, pageable);
 
         List<CourseDto.MyCourseItem> items = result.getContent().stream()
                 .map(uc -> {
@@ -128,8 +128,8 @@ public class CourseService {
                             .imageUrl(c.getImageUrl())
                             .progress(CourseProgressDto.of(
                                     percent,
-                                    cnt.completedLectures(),
-                                    cnt.totalLectures(),
+                                    (int) cnt.completedLectures(),
+                                    (int) cnt.totalLectures(),
                                     completeThreshold
                             ))
                             .build();
@@ -146,6 +146,7 @@ public class CourseService {
                 .build();
     }
     /** 결제 직전 노출용(공개 코스만) */
+    @Transactional(readOnly = true)
     public CoursePurchasePreviewDto getPurchasePreview(Long courseId) {
         Course c = courseRepository.findByIdAndPublishedTrueAndDeletedFalse(courseId)
                 .orElseThrow(() -> new NotFoundException("course"));


### PR DESCRIPTION
- DTO 정리(CourseDto)
  - MyCourseItem에서 progress만 노출(CourseProgressDto)
  - legacy 필드 completedCount/totalCount 제거
  - CreateRequest.image는 선택값(Nullable)로 문서화

- 서비스 정리(CourseService)
  - findMyCourses(): CourseProgressService 기반으로 진행률 계산 · progressPercent(강의 길이 가중 평균, 0~100) · completedLectures / totalLectures / completed
  - createProduct(): 이미지가 null/빈 파일이면 업로드 건너뛰고 imageUrl 생략(또는 null 저장)
  - getPurchasePreview(): 강의 개수/총 길이(초) 포함 반환 유지

- API 응답 변화
  - /api/course/me: 진행 정보는 data.content[].progress.* 로 통일 (progressPercent / completedLectures / totalLectures / completed)

BREAKING CHANGE: completedCount/totalCount 상위 필드 제거 → 프런트는 progress 하위 필드 사용 필요