### PR TITLE
fix(progress): 진행도 업데이트 바디 매핑/중복 매핑 오류 수정 및 안정화

### DIFF
--- a/src/main/java/com/example/ei_backend/controller/LectureController.java
+++ b/src/main/java/com/example/ei_backend/controller/LectureController.java
@@ -11,11 +11,11 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -24,6 +24,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
+@Slf4j
 @Tag(name = "Lecture", description = "강의 생성/수정/삭제, 조회, 진행도 업데이트 API")
 @RestController
 @RequiredArgsConstructor
@@ -32,13 +33,11 @@ import java.util.List;
 // @SecurityRequirement(name = "bearerAuth")     // Bearer 사용 시 교체
 public class LectureController {
 
-    private final LectureProgressService lectureProgressService;
     private final LectureCommandService lectureCommandService;
     private final LectureQueryService lectureQueryService;
     private final ProgressService progressService;
     private final LectureCreateWithVideoService createWithVideoService;
     private final ObjectMapper objectMapper;
-    private final CourseProgressService courseProgressService;
 
     /** ADMIN: 멀티파트(강의 + 영상 한번에) */
     @Operation(
@@ -236,6 +235,9 @@ public class LectureController {
             @PathVariable Long lectureId,
             @RequestBody @Valid ProgressUpdateRequest req
     ) {
+        log.info("[progress:req] userId={}, lectureId={}, watchedSec={}, completed={}",
+                me.getUserId(), lectureId, req.getWatchedSec(), req.isCompleted());
+
         // ProgressService는 아래 시그니처로 맞춰주세요.
         var dto = progressService.update(
                 me.getUserId(),

--- a/src/main/java/com/example/ei_backend/domain/dto/lecture/ProgressUpdateRequest.java
+++ b/src/main/java/com/example/ei_backend/domain/dto/lecture/ProgressUpdateRequest.java
@@ -1,21 +1,23 @@
 package com.example.ei_backend.domain.dto.lecture;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
-@Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ProgressUpdateRequest {
 
-
-    @NotNull
+    // 직렬화 키는 watchedSec, 입력은 watchedSec / watched_sec / positionSec 허용
+    @JsonProperty("watchedSec")
+    @JsonAlias({"watched_sec", "positionSec"})
+    @NotNull(message = "watchedSec는 필수입니다.")
+    @Min(value = 0, message = "watchedSec는 0 이상이어야 합니다.")
     private Integer watchedSec;
 
     private boolean completed;
-
 }


### PR DESCRIPTION
- API
  - POST /api/lectures/{lectureId}/progress 엔드포인트를 LectureController로 단일화
  - 중복 매핑 원인이던 LectureProgressController 제거 → Ambiguous mapping 해소

- DTO(ProgressUpdateRequest)
  - @JsonAlias로 입력 키 다양화: watchedSec / watched_sec / positionSec 모두 허용
  - @JsonProperty("watchedSec")로 응답 직렬화 키 고정
  - @JsonIgnoreProperties(ignoreUnknown = true)로 불명 키 무시
  - @NotNull, @Min(0) 검증 및 한글 메시지 적용

- Controller
  - Spring MVC @RequestBody(@Valid)만 사용하도록 정리 (OpenAPI @RequestBody 제거)
  - 진행 업데이트 요청 로그 추가(선택): [progress:req] userId, lectureId, watchedSec, completed

- Service
  - ProgressService.update(userId, lectureId, watchedSec, completed) 시그니처로 통일
  - LectureProgressService.updateProgress(...)에 위임하여 INSERT/UPDATE 및 완료 정규화(완료 시 watchedSec=durationSec) 수행
  - 저장 후 상태 확인 로그 추가(선택): [progress:db] savedWatchedSec, completed

BREAKING CHANGE: 강의 진행도 업데이트 엔드포인트는 LectureController 단일 엔드포인트만 유효