### PR TITLE
feat: 회원 응답 DTO에 isDeleted 필드 추가 및 JSON 키 고정

### DIFF
--- a/src/main/java/com/example/ei_backend/domain/dto/UserDto.java
+++ b/src/main/java/com/example/ei_backend/domain/dto/UserDto.java
@@ -3,6 +3,7 @@ package com.example.ei_backend.domain.dto;
 import com.example.ei_backend.domain.UserRole;
 import com.example.ei_backend.domain.entity.User;
 import com.example.ei_backend.validation.ValidPassword;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -49,8 +50,13 @@ public class UserDto {
         private String name;
         private String token;
         private String phone;
-        private String birthDate;
+
+        @JsonProperty("isSocial")
         private boolean isSocial;
+
+        @JsonProperty("isDeleted")
+        private boolean isDeleted;
+
         private String imageUrl;
         private Set<UserRole> roles;
 
@@ -66,6 +72,7 @@ public class UserDto {
                     .imageUrl(user.getProfileImage() != null ? user.getProfileImage().getImageUrl() : null)
                     .roles(user.getRoles())
                     .isSocial(user.isSocial())
+                    .isDeleted(user.isDeleted())
                     .token(token)
                     .build();
         }
@@ -85,6 +92,7 @@ public class UserDto {
                     .imageUrl(user.getProfileImage() != null ? user.getProfileImage().getImageUrl() : null)
                     .roles(user.getRoles())
                     .isSocial(user.isSocial())
+                    .isDeleted(user.isDeleted())
                     .build();
         }
     }

--- a/src/main/java/com/example/ei_backend/mapper/UserMapper.java
+++ b/src/main/java/com/example/ei_backend/mapper/UserMapper.java
@@ -21,6 +21,7 @@ public interface UserMapper {
     @Mapping(source = "roles", target = "roles")
     @Mapping(source = "phone", target = "phone")
     @Mapping(source = "social", target = "isSocial")
+    @Mapping(source = "deleted", target = "isDeleted")
     @Mapping(target = "imageUrl", expression = "java(user.getProfileImage() != null ? user.getProfileImage().getImageUrl() : null)")
     UserDto.Response toResponse(User user);
 


### PR DESCRIPTION
- UserDto.Response DTO에 `isDeleted` 필드 추가
  - @JsonProperty("isDeleted") 적용하여 JSON 키 이름 명확히 고정
  - 기존 boolean getter/setter 네이밍 문제로 응답에서 누락되던 이슈 해결
- UserDto.Response에 @JsonProperty("isSocial") 적용 → JSON 키를 isSocial로 고정
- UserMapper 수정
  - `deleted -> isDeleted` 매핑 명시
  - `birthDate(LocalDate)` → String 변환(dateFormat = "yyyy-MM-dd") 추가
  - profileImage → imageUrl 변환 로직 유지
- Swagger 예시 응답 JSON에 isDeleted 필드 반영