### PR TITLE
출석 스키마 및 저장/조회 기본 구조 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,5 +52,87 @@
 
 | 이름                                         | 진행 사항 |
 | -------------------------------------------- | --------- |
-| [**이동현**](https://github.com/soohofather) | ✅ <br>✅   |
-| [**하민철**](https://github.com/teotaku)     | ✅ <br>✅   |
+| [**이동현**](https://github.com/soohofather) | 프론트엔드 개발 및 UI 구현  |
+| [**하민철**](https://github.com/teotaku)     | 백엔드 개발 및 배포 환경 구성   |
+
+## 5️⃣ 프로젝트 소개 (Architecture & Design)
+
+동철코딩은 Spring Boot 기반 교육 플랫폼으로,
+계층형 아키텍처(Layered Architecture) 위에 **도메인 모델 패턴(Domain Model Pattern)**을 적용하여 개발된 모놀리식 애플리케이션입니다.
+
+🔹 아키텍처
+
+3계층 구조: Controller → Service → Repository
+
+주요 도메인(회원, 강의, 결제, 마이페이지, 채팅)을 단일 애플리케이션 안에서 관리
+
+🔹 도메인 모델 패턴
+
+User 엔티티 내부에 validatePassword(), softDelete(), bumpTokenVersion() 같은 비즈니스 로직 포함
+
+단순 데이터 보관이 아닌, 풍부한 도메인 모델로 비즈니스 규칙을 캡슐화
+
+🔹 영속성 계층
+
+Spring Data JPA Repository로 데이터 접근 추상화
+
+Specification<User>와 @EntityGraph를 활용하여 동적 검색 + 성능 최적화 구현
+
+🔹 표현 계층
+
+UserDto.Request, UserDto.Response로 API 입출력 분리
+
+MapStruct 기반의 DTO ↔ Entity 변환으로 반복 코드 제거
+
+🔹 인증 및 보안
+
+JWT 기반 Stateless 인증 (AccessToken + RefreshToken)
+
+JwtAuthenticationFilter로 매 요청 인증/인가 처리
+
+🔹 데이터 관리
+
+isDeleted, deletedAt, deletedReason 필드로 Soft Delete 패턴 적용
+
+회원 탈퇴 시 이메일을 deleted-{id}@user.invalid로 익명화하여 유니크 제약 충돌 방지 + 개인정보 보호 강화
+
+## 6️⃣ API 설계 철학 (Design Philosophy)
+
+동철코딩 백엔드의 API는 단순 CRUD를 넘어서, 보안·데이터 정합성·성능 최적화·개인정보 보호를 고려하여 설계되었습니다.
+각 기능마다 문제 상황 → 고민 → 최종 의사결정 과정을 거쳐 실제 서비스 운영 환경에 적합한 구조를 선택했습니다.
+
+🔹 회원가입 & 이메일 인증
+
+문제: 잘못된 이메일·중복 가입 방지 필요
+
+해결: EmailVerification 엔티티를 통해 인증 코드와 요청 JSON을 저장 → 만료 검증 후 최종 회원가입
+
+🔹 로그인 & JWT 인증
+
+문제: 세션 방식은 확장성에 한계
+
+해결: AccessToken + RefreshToken 구조, tokenVersion 필드로 탈퇴/비밀번호 변경 시 토큰 무효화
+
+🔹 회원 탈퇴
+
+문제: Hard Delete 시 결제·수강 이력 정합성 깨짐
+
+해결: Soft Delete(isDeleted) + 개인정보 익명화(deleted-{id}@user.invalid) → 유니크 충돌 방지 및 보안 강화
+
+🔹 결제 API (KakaoPay 연동)
+
+문제: Ready 성공 후 Approve 실패 시 데이터 불일치
+
+해결: PendingPayment 테이블로 중간 상태 저장, Approve 성공 시에만 Payment/UserCourse 생성
+
+🔹 코스 진행률
+
+문제: 단순 시청 완료 여부만 저장하면 세부 진행률 불가
+
+해결: LectureProgress 엔티티에 watchedSec, completed 저장 → 90% 이상 시 자동 완료 처리
+
+🔹 관리자 회원 검색
+
+문제: 전체 조회 후 필터링은 성능 저하 및 N+1 문제 발생
+
+해결: Spring Data JPA Specification + @EntityGraph로 동적 검색 및 성능 최적화

--- a/src/main/java/com/example/ei_backend/controller/AttendanceController.java
+++ b/src/main/java/com/example/ei_backend/controller/AttendanceController.java
@@ -1,0 +1,40 @@
+package com.example.ei_backend.controller;
+
+import com.example.ei_backend.config.ApiResponse;
+import com.example.ei_backend.security.UserPrincipal;
+import com.example.ei_backend.service.AttendanceQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/courses/{courseId}/attendance")
+@RequiredArgsConstructor
+public class AttendanceController {
+
+    private final AttendanceQueryService qs;
+
+    @GetMapping("/dates")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "코스 출석 날짜 조회(8주 자동)", description = "결제/수강 시작일 기준 8주 범위를 자동 계산하여 날짜 배열 반환")
+    public ResponseEntity<ApiResponse<DatesDto>> dates8Weeks(
+            @PathVariable Long courseId,
+            @AuthenticationPrincipal UserPrincipal me,
+            @RequestParam(required = false) String scope // "8weeks" 외에는 추후 확장 대비
+    ) {
+        // scope가 비어있어도 기본은 8weeks로 동작하도록 처리
+        var dates = qs.listEightWeeks(me.getUserId(), courseId);
+
+        // 응답에 from/to도 같이 주고 싶다면 resolver를 주입 받아 다시 계산해 포함 가능
+        // 여기서는 간단히 날짜 배열만 반환
+        return ResponseEntity.ok(ApiResponse.ok(new DatesDto(me.getUserId(), courseId, dates)));
+    }
+
+    public record DatesDto(Long userId, Long courseId, List<LocalDate> attendance) {}
+}

--- a/src/main/java/com/example/ei_backend/controller/PlaybackController.java
+++ b/src/main/java/com/example/ei_backend/controller/PlaybackController.java
@@ -1,0 +1,47 @@
+package com.example.ei_backend.controller;
+
+import com.example.ei_backend.config.ApiResponse;
+import com.example.ei_backend.security.UserPrincipal;
+import com.example.ei_backend.service.AttendanceService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/lectures")
+@RequiredArgsConstructor
+public class PlaybackController {
+
+    private final AttendanceService attendanceService;
+
+    @PostMapping("/{lectureId}/playback/start")
+    @PreAuthorize("hasRole('MEMBER')")
+    @Operation(summary = "재생 시작(출석 발생)", description = "강의 재생 순간 1회 호출, 코스별 1일 1회 출석 생성")
+    public ResponseEntity<ApiResponse<Void>> playbackStart(
+            @PathVariable Long lectureId,
+            @AuthenticationPrincipal UserPrincipal me,
+            HttpServletRequest req
+    ) {
+        String ip = clientIp(req);
+        String ua = req.getHeader("User-Agent");
+        attendanceService.markIfFirstPlayback(me.getUserId(), lectureId, ip, ua);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    private String clientIp(HttpServletRequest req) {
+        String xf = req.getHeader("X-Forwarded-For");
+        if (xf != null && !xf.isBlank()) {
+            int idx = xf.indexOf(',');
+            return (idx > 0) ? xf.substring(0, idx).trim() : xf.trim();
+        }
+        String xr = req.getHeader("X-Real-IP");
+        return (xr != null && !xr.isBlank()) ? xr : req.getRemoteAddr();
+    }
+}

--- a/src/main/java/com/example/ei_backend/domain/entity/Attendance.java
+++ b/src/main/java/com/example/ei_backend/domain/entity/Attendance.java
@@ -4,23 +4,46 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
 
 @Entity
-@Table(name = "attendance")
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Builder
+@Table(name = "attendance",
+        uniqueConstraints = @UniqueConstraint(
+                name = "ux_att_user_course_date",
+                columnNames = {"user_id", "course_id", "attend_date"}
+        ))
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
 public class Attendance {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private UserCourse userCourse;
+    @Column(name="user_id",   nullable=false)
+    private Long userId;
 
-    private LocalDate date;
+    @Column(name="course_id", nullable=false)
+    private Long courseId;
 
-    private boolean attended;
+    @Column(name="attend_date", nullable=false)
+    private LocalDate attendDate; // KST 날짜
+
+    @Column(name="lecture_id")
+    private Long lectureId; // 메타
+
+    @Column(name="first_played_at", nullable=false)
+    private LocalDateTime firstPlayedAt; // KST 시각
+
+    private String userAgent;
+    private String ipAddress;
+
+    @Column(nullable=false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    void onCreate() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        }
+    }
 }

--- a/src/main/java/com/example/ei_backend/repository/AttendanceRepository.java
+++ b/src/main/java/com/example/ei_backend/repository/AttendanceRepository.java
@@ -1,0 +1,28 @@
+package com.example.ei_backend.repository;
+
+import com.example.ei_backend.domain.entity.Attendance;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
+
+    Optional<Attendance> findByUserIdAndCourseIdAndAttendDate(
+            Long userId, Long courseId, LocalDate attendDate
+    );
+
+    @Query("""
+            select a.attendDate from Attendance a
+                        where a.userId = :userId
+                                    and a.courseId = :courseId
+                                                and a.attendDate between :from and :to
+                                                            order by  a.attendDate asc
+            """)
+    List<LocalDate> findDatesInRange(Long userId, Long courseId, LocalDate from, LocalDate to);
+
+}

--- a/src/main/java/com/example/ei_backend/repository/UserCourseRepository.java
+++ b/src/main/java/com/example/ei_backend/repository/UserCourseRepository.java
@@ -8,15 +8,16 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
+
 public interface UserCourseRepository extends JpaRepository<UserCourse, Long> {
 
     boolean existsByUserIdAndCourseId(Long userId, Long courseId);
 
-    // 페이징 + 연관로딩은 EntityGraph 추천 (안전)
     @EntityGraph(attributePaths = {"course"})
     Page<UserCourse> findByUser_Id(Long userId, Pageable pageable);
 
-    // fetch join 꼭 써야 한다면 countQuery 분리
     @Query(
             value = """
             select uc from UserCourse uc
@@ -29,4 +30,7 @@ public interface UserCourseRepository extends JpaRepository<UserCourse, Long> {
         """
     )
     Page<UserCourse> findByUser_IdWithCourse(@Param("userId") Long userId, Pageable pageable);
+
+    // ✅ 8주 시작일 조회용: 엔티티 자체를 가져옵니다.
+    Optional<UserCourse> findByUser_IdAndCourse_Id(Long userId, Long courseId);
 }

--- a/src/main/java/com/example/ei_backend/service/AttendanceQueryService.java
+++ b/src/main/java/com/example/ei_backend/service/AttendanceQueryService.java
@@ -1,0 +1,29 @@
+package com.example.ei_backend.service;
+
+import com.example.ei_backend.repository.AttendanceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AttendanceQueryService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final AttendanceRepository repo;
+    private final EightWeekStartDateResolver startDateResolver;
+
+    public List<LocalDate> listEightWeeks(Long userId, Long courseId) {
+        LocalDate start = startDateResolver.resolve(userId, courseId); // KST 기준 날짜
+        LocalDate end   = start.plusWeeks(8).minusDays(1);
+        return repo.findDatesInRange(userId, courseId, start, end);
+    }
+
+    public interface EightWeekStartDateResolver {
+        LocalDate resolve(Long userId, Long courseId);
+    }
+}

--- a/src/main/java/com/example/ei_backend/service/AttendanceService.java
+++ b/src/main/java/com/example/ei_backend/service/AttendanceService.java
@@ -1,0 +1,74 @@
+package com.example.ei_backend.service;
+
+import com.example.ei_backend.domain.entity.Attendance;
+import com.example.ei_backend.repository.AttendanceRepository;
+import com.example.ei_backend.repository.LectureRepository;
+import com.example.ei_backend.repository.UserCourseRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AttendanceService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final AttendanceRepository attendanceRepository;
+    private final LectureRepository lectureRepository;
+    private final UserCourseRepository userCourseRepository;
+
+    /**
+     * 강의 재생 시작 시 호출: 코스별 1일 1회 출석 생성
+     */
+    @Transactional
+    public void markIfFirstPlayback(Long userId, Long lectureId, String ip, String ua) {
+        // 1) lectureId -> courseId
+        Long courseId = lectureRepository.findById(lectureId)
+                .map(l -> l.getCourse().getId())
+                .orElseThrow(() -> new EntityNotFoundException("Lecture not found: " + lectureId));
+
+        // 2) 수강권 검증
+        boolean owned = userCourseRepository.existsByUserIdAndCourseId(userId, courseId);
+        if (!owned) {
+            throw new AccessDeniedException("Not enrolled in course: " + courseId);
+        }
+
+        // 3) 오늘 날짜(KST)
+        LocalDate today = LocalDate.now(KST);
+
+        // 4) 이미 있으면 조용히 종료
+        if (attendanceRepository.findByUserIdAndCourseIdAndAttendDate(userId, courseId, today).isPresent()) {
+            return;
+        }
+
+        // 5) 저장 시도 (동시성은 UNIQUE 제약으로 보장)
+        Attendance row = Attendance.builder()
+                .userId(userId)
+                .courseId(courseId)
+                .attendDate(today)
+                .lectureId(lectureId) // 메타
+                .firstPlayedAt(LocalDateTime.now(KST))
+                .ipAddress(ip)
+                .userAgent(ua)
+                .build();
+
+        try {
+            attendanceRepository.save(row);
+            log.info("[attendance] created user={} course={} date={} lecture={} ip={}",
+                    userId, courseId, today, lectureId, ip);
+        } catch (DataIntegrityViolationException e) {
+            // 레이스로 인한 UNIQUE 충돌 → 이미 다른 트랜잭션이 선점
+            log.debug("[attendance] duplicate (race) user={} course={} date={}", userId, courseId, today);
+        }
+    }
+}

--- a/src/main/java/com/example/ei_backend/service/UserCourseStartDateResolver.java
+++ b/src/main/java/com/example/ei_backend/service/UserCourseStartDateResolver.java
@@ -1,0 +1,26 @@
+package com.example.ei_backend.service;
+
+import com.example.ei_backend.repository.UserCourseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+
+@Service
+@RequiredArgsConstructor
+public class UserCourseStartDateResolver implements AttendanceQueryService.EightWeekStartDateResolver {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private final UserCourseRepository userCourseRepository;
+
+    @Override
+    public LocalDate resolve(Long userId, Long courseId) {
+        return userCourseRepository.findByUser_IdAndCourse_Id(userId, courseId)
+                .map(uc -> uc.getRegisteredAt().atZone(KST).toLocalDate())
+                .orElseThrow(() -> new IllegalStateException(
+                        "UserCourse not found for user=" + userId + ", course=" + courseId));
+
+    }
+}


### PR DESCRIPTION
DDL: attendance 테이블 생성
id, user_id, course_id, attend_date(KST), lecture_id, first_played_at(KST), user_agent, ip_address, created_at

UNIQUE (user_id, course_id, attend_date)로 코스별 1일 1회 보장
인덱스: (user_id, course_id, attend_date)
엔티티/레포: Attendance, AttendanceRepository
서비스 뼈대: AttendanceService, AttendanceQueryService

feat(playback): 재생 시작 시 출석 생성 API 추가
POST /api/lectures/{lectureId}/playback/start (ROLE_MEMBER)
AttendanceService.markIfFirstPlayback(userId, lectureId, ip, ua)
lectureId → courseId 매핑, 수강권 검증, KST 기준 오늘 날짜 저장
중복 시 무시(유니크 충돌 흡수)
PlaybackController 추가
클라이언트 IP 추출(X-Forwarded-For, X-Real-IP 처리)

feat(attendance): 8주 자동 조회 API 추가
GET /api/courses/{courseId}/attendance/dates
기준일: UserCourse.registeredAt → from
to = from.plusWeeks(8).minusDays(1)
응답: { userId, courseId, from, to, attendance: LocalDate[] }
AttendanceQueryService.listEightWeeks, UserCourseStartDateResolver 추가
UserCourseRepository.findByUser_IdAndCourse_Id 추가
refactor(attendance): LectureRepository 직접 주입으로 간소화
LectureQuery 인터페이스 제거
AttendanceService에서 LectureRepository, UserCourseRepository 직접 주입

fix(api): ApiResponse<Void> 반환 시 ok(null) 사용
ApiResponse.ok() 오버로드 부재로 컴파일 오류 → ApiResponse.ok(null)로 통일
나중에 무인자 ok() 오버로드 추가 고려

fix(timezone): 상수 KST(Asia/Seoul) 누락 보완
서비스/리졸버 클래스에 private static final ZoneId KST = ZoneId.of("Asia/Seoul"); 정의
chore(doc): API 계약/흐름/테스트 시나리오 문서화
저장/조회 플로우 명세
프론트 연동 가이드(재생 시 1회 호출, 조회 시 8주 자동)