### PR TITLE
feat(attendance): 출석 여부 컬럼(attended) 추가 및 기본값 설정

### DIFF
--- a/src/main/java/com/example/ei_backend/domain/entity/Attendance.java
+++ b/src/main/java/com/example/ei_backend/domain/entity/Attendance.java
@@ -7,43 +7,63 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 
-
 @Entity
 @Table(name = "attendance",
         uniqueConstraints = @UniqueConstraint(
                 name = "ux_att_user_course_date",
                 columnNames = {"user_id", "course_id", "attend_date"}
         ))
-@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Attendance {
+
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name="user_id",   nullable=false)
+    @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @Column(name="course_id", nullable=false)
+    @Column(name = "course_id", nullable = false)
     private Long courseId;
 
-    @Column(name="attend_date", nullable=false)
-    private LocalDate attendDate; // KST 날짜
+    // 출석일은 KST 기준 날짜로 저장
+    @Column(name = "attend_date", nullable = false)
+    private LocalDate attendDate;
 
-    @Column(name="lecture_id")
-    private Long lectureId; // 메타
+    // 메타: 어떤 강의로 출석 트리거됐는지
+    @Column(name = "lecture_id")
+    private Long lectureId;
 
-    @Column(name="first_played_at", nullable=false)
-    private LocalDateTime firstPlayedAt; // KST 시각
+    // 최초 재생 시각
+    @Column(name = "first_played_at", nullable = false)
+    private LocalDateTime firstPlayedAt;
 
     private String userAgent;
     private String ipAddress;
 
-    @Column(nullable=false)
+    @Column(nullable = false)
     private LocalDateTime createdAt;
+
+    /** 출석 여부: 기본 false */
+    @Column(name = "attended", nullable = false)
+    @Builder.Default
+    private boolean attended = false;
 
     @PrePersist
     void onCreate() {
+        var kst = ZoneId.of("Asia/Seoul");
         if (createdAt == null) {
-            createdAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+            createdAt = LocalDateTime.now(kst);
         }
+        // 방어적 기본값 세팅
+        if (firstPlayedAt == null) {
+            firstPlayedAt = LocalDateTime.now(kst);
+        }
+        if (attendDate == null) {
+            attendDate = LocalDate.now(kst);
+        }
+        // attended는 primitive boolean + @Builder.Default 로 이미 false 보장
     }
 }


### PR DESCRIPTION
attendance 테이블에 attended 컬럼 관리 강화
기존 NULL 값 → 0 으로 초기화 (UPDATE attendance SET attended = 0 WHERE attended IS NULL) attended 컬럼을 TINYINT(1) NOT NULL DEFAULT 0 으로 변경
출석 여부를 0=미출석, 1=출석 플래그로 명확하게 관리 가능