### PR TITLE
feat(chat): DB 커밋 이후에만 STOMP 발행하도록 구조 개선 (afterCommit)

### DIFF
--- a/src/main/java/com/example/ei_backend/controller/ChatStompController.java
+++ b/src/main/java/com/example/ei_backend/controller/ChatStompController.java
@@ -1,14 +1,10 @@
 package com.example.ei_backend.controller;
 
 import com.example.ei_backend.domain.dto.chat.ChatMessageRequestDto;
-import com.example.ei_backend.domain.dto.chat.ChatMessageResponseDto;
-import com.example.ei_backend.domain.entity.chat.ChatMessage;
 import com.example.ei_backend.service.ChatService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
-
 import java.security.Principal;
 
 @Controller
@@ -16,32 +12,9 @@ import java.security.Principal;
 public class ChatStompController {
 
     private final ChatService chatService;
-    private final SimpMessagingTemplate messagingTemplate;
 
-    // 클라이언트: destination="/app/chat.send"
     @MessageMapping("/chat.send")
     public void send(ChatMessageRequestDto reqDto, Principal principal) {
-        String senderEmail = principal.getName();
-
-        // 1) DB 저장 + 권한 체크(참여자인지) (네 서비스 그대로 사용)
-        ChatMessage saved = chatService.sendMessage(reqDto.getChatRoomId(), senderEmail, reqDto.getMessage());
-
-        // 2) 수신자 식별
-        var room = saved.getChatRoom();
-        String memberEmail  = room.getMember().getEmail();
-        String supportEmail = room.getSupport().getEmail();
-        String recipientEmail = senderEmail.equals(memberEmail) ? supportEmail : memberEmail;
-
-        // 3) 페이로드
-        var payload = ChatMessageResponseDto.from(saved);
-
-        // 4) 개인 큐로 전송 (상대 + 본인 동기화)
-        messagingTemplate.convertAndSendToUser(recipientEmail, "/queue/messages", payload);
-        messagingTemplate.convertAndSendToUser(senderEmail,   "/queue/messages", payload);
-
-        // (선택) 방 토픽으로는 타이핑 표시/입장알림 같은 메타 이벤트만 쏘세요
-        // messagingTemplate.convertAndSend("/topic/chatroom/" + reqDto.getChatRoomId(),
-        //         new TypingEventDto(...));
+        chatService.sendMessage(reqDto.getChatRoomId(), principal.getName(), reqDto.getMessage());
     }
-
 }


### PR DESCRIPTION
- ChatService
  - @Transactional sendMessage 내에서 메시지 저장/권한검사 수행
  - 트랜잭션 안에서 recipientEmail/payload/msgId 확정
  - TransactionSynchronization.afterCommit()에서만 /user/queue/messages 발행
  - SimpMessagingTemplate 서비스로 이동 주입
  - 로그 추가: [chat] committed => to=..., from=..., msgId=...

- ChatStompController
  - 브로커 발행 로직 삭제, 서비스 위임 전용으로 단순화
  - 불필요한 SimpMessagingTemplate 의존성/임포트 제거

- WebSocketConfig
  - JwtHandshakeInterceptor / UserPrincipalHandshakeHandler / JwtStompChannelInterceptor 유지
  - allowed origins 운영 도메인으로 제한 (dongcheolcoding.life, api.dongcheolcoding.life, localhost:3000)
  - /ws-chat, /ws-chat-sockjs, /api/ws-chat, /api/ws-chat-sockjs 엔드포인트 구성
  - setUserDestinationPrefix("/user"), setPreservePublishOrder(true) 유지

Why
- DB에 저장 실패/롤백 시 클라이언트가 ‘유령 메시지’를 받지 않도록 정합성 보장
- 컨트롤러의 트랜잭션/영속성 의존 제거, 계층 책임 분리

Impact
- 외부 API/스키마 변경 없음 (구독 경로: /user/queue/messages 유지)
- 발행 시점이 ‘커밋 후’로 지연되어 수 ms 레이턴시 증가 가능

Test
- 두 계정으로 /user/queue/messages 구독, /app/chat.send 전송 시 양쪽 수신 확인
- closeRoom 후 전송 시 CHAT_ROOM_CLOSED 예외 확인
- 서버 로그에서 afterCommit 로그 확인

Refs: #chat, #stomp, #consistency